### PR TITLE
Add CI environment setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        target: thumbv7em-none-eabihf
-        profile: minimal
+    - name: Prepare build environment
+      run: bash scripts/setup-ci-env.sh
     - run: rustup component add rustfmt clippy
     - run: cargo build --workspace --verbose
     - run: cargo fmt --all -- --check

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -19,9 +19,17 @@ pub struct StyleBuilder {
     style: Style,
 }
 
+impl Default for StyleBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StyleBuilder {
     pub fn new() -> Self {
-        Self { style: Style::default() }
+        Self {
+            style: Style::default(),
+        }
     }
 
     pub fn bg_color(mut self, color: crate::widget::Color) -> Self {

--- a/scripts/setup-ci-env.sh
+++ b/scripts/setup-ci-env.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Install packages and tools needed for CI builds.
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    curl \
+    wget \
+    git \
+    nano \
+    vim \
+    python3 \
+    python3-venv \
+    python3-pip \
+    cargo \
+    cmake \
+    ninja-build \
+    llvm-dev \
+    libclang-dev \
+    clang \
+    libsdl2-dev \
+    xvfb \
+    libxrender1 \
+    libfreetype6-dev \
+    libx11-dev \
+    libxext-dev \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+git submodule update --init --recursive
+
+# Install Rust using rustup
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+source "$HOME/.cargo/env"
+rustup component add rust-src llvm-tools-preview
+rustup target add thumbv7em-none-eabihf
+
+# Create Python virtual environment
+sudo python3 -m venv /opt/venv
+
+# Propagate environment updates to subsequent workflow steps
+echo "PATH=/opt/venv/bin:$HOME/.cargo/bin:$PATH" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- create a CI environment bootstrap script mirroring the Dockerfile
- run this script in the workflow before building
- implement `Default` for `StyleBuilder` to satisfy Clippy

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --target x86_64-unknown-linux-gnu -- -D warnings`
- `cargo test --workspace --target x86_64-unknown-linux-gnu --verbose`
- `cargo build --workspace --target x86_64-unknown-linux-gnu --verbose`


------
https://chatgpt.com/codex/tasks/task_e_688659986ff483339784b95ccfda5975