### PR TITLE
Add embedded ST7789 driver

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,7 +26,7 @@ This document tracks the high-level work streams and tasks for rlvgl development
 - [x] Define `DisplayDriver` trait (`flush(Rect, &[Color])`)
 - [x] Define `InputDevice` trait (`poll() -> Option<InputEvent>`)
 - [x] Provide dummy stub driver for headless tests
-- [ ] SPI-based example driver (`st7789`) using `embedded-hal`
+- [x] SPI-based example driver (`st7789`) using `embedded-hal`
 
 ## 4 Tier 1 widget translations
 - [x] Label (text-only)
@@ -35,9 +35,9 @@ This document tracks the high-level work streams and tasks for rlvgl development
 - [ ] Unit tests + golden screenshots via dummy driver
 
 ## 5 Simulation backend
-- [ ] Add simulator feature flag (`std`, pixels, or minifb)
-- [ ] Map `DisplayDriver` to desktop window
-- [ ] Connect keyboard/mouse to `InputDevice` trait
+- [x] Add simulator feature flag (`std`, pixels, or minifb)
+- [x] Map `DisplayDriver` to desktop window
+- [x] Connect keyboard/mouse to `InputDevice` trait
 - [ ] CI step: run example, dump PNG for diff
 
 ## 6 Tier 2 widget translations

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -5,3 +5,15 @@ edition = "2021"
 
 [dependencies]
 rlvgl-core = { path = "../core" }
+embedded-hal = { version = "1.0", optional = true }
+display-interface = { version = "0.5", optional = true }
+display-interface-spi = { version = "0.5", optional = true }
+
+[features]
+default = []
+simulator = ["minifb"]
+st7789 = ["embedded-hal", "display-interface", "display-interface-spi"]
+
+[dependencies.minifb]
+version = "0.24"
+optional = true

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -1,5 +1,13 @@
 pub mod display;
 pub mod input;
+#[cfg(feature = "simulator")]
+pub mod simulator;
+#[cfg(feature = "st7789")]
+pub mod st7789;
 
 pub use display::DisplayDriver;
 pub use input::{InputDevice, InputEvent};
+#[cfg(feature = "simulator")]
+pub use simulator::MinifbDisplay;
+#[cfg(feature = "st7789")]
+pub use st7789::St7789Display;

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -1,0 +1,88 @@
+#[cfg(feature = "simulator")]
+use crate::{display::DisplayDriver, input::InputDevice};
+#[cfg(feature = "simulator")]
+use minifb::{MouseButton, MouseMode, Window, WindowOptions};
+#[cfg(feature = "simulator")]
+use rlvgl_core::{
+    event::Event,
+    widget::{Color, Rect},
+};
+
+#[cfg(feature = "simulator")]
+pub struct MinifbDisplay {
+    window: Window,
+    width: usize,
+    height: usize,
+    buffer: Vec<u32>,
+    mouse_down: bool,
+    last_pos: Option<(i32, i32)>,
+}
+
+#[cfg(feature = "simulator")]
+impl MinifbDisplay {
+    pub fn new(width: usize, height: usize) -> Self {
+        let window = Window::new("rlvgl simulator", width, height, WindowOptions::default())
+            .expect("failed to create window");
+        let buffer = vec![0; width * height];
+        Self {
+            window,
+            width,
+            height,
+            buffer,
+            mouse_down: false,
+            last_pos: None,
+        }
+    }
+
+    fn update(&mut self) {
+        let _ = self
+            .window
+            .update_with_buffer(&self.buffer, self.width, self.height);
+    }
+}
+
+#[cfg(feature = "simulator")]
+impl DisplayDriver for MinifbDisplay {
+    fn flush(&mut self, area: Rect, colors: &[Color]) {
+        for y in 0..area.height as usize {
+            for x in 0..area.width as usize {
+                let idx = (area.y as usize + y) * self.width + (area.x as usize + x);
+                let color = colors[y * area.width as usize + x];
+                self.buffer[idx] =
+                    ((color.0 as u32) << 16) | ((color.1 as u32) << 8) | (color.2 as u32);
+            }
+        }
+        self.update();
+    }
+}
+
+#[cfg(feature = "simulator")]
+impl InputDevice for MinifbDisplay {
+    fn poll(&mut self) -> Option<Event> {
+        let pos = self
+            .window
+            .get_mouse_pos(MouseMode::Clamp)
+            .map(|(x, y)| (x as i32, y as i32));
+        let down = self.window.get_mouse_down(MouseButton::Left);
+
+        let mut event = None;
+        if down != self.mouse_down {
+            self.mouse_down = down;
+            if down {
+                if let Some((x, y)) = pos {
+                    event = Some(Event::PointerDown { x, y });
+                }
+            } else {
+                if let Some((x, y)) = pos {
+                    event = Some(Event::PointerUp { x, y });
+                }
+            }
+        } else if pos != self.last_pos {
+            if let Some((x, y)) = pos {
+                event = Some(Event::PointerMove { x, y });
+            }
+        }
+        self.last_pos = pos;
+        event
+    }
+}

--- a/platform/src/st7789.rs
+++ b/platform/src/st7789.rs
@@ -1,0 +1,60 @@
+#![cfg(feature = "st7789")]
+use embedded_hal::digital::OutputPin;
+use embedded_hal::spi::SpiDevice;
+use rlvgl_core::widget::{Color, Rect};
+use crate::display::DisplayDriver;
+use display_interface::{DisplayError, DataFormat, WriteOnlyDataCommand};
+use display_interface_spi::SPIInterface;
+
+pub struct St7789Display<SPI, DC> {
+    interface: SPIInterface<SPI, DC>,
+    width: u16,
+    height: u16,
+}
+
+impl<SPI, DC> St7789Display<SPI, DC>
+where
+    SPI: SpiDevice,
+    DC: OutputPin,
+{
+    pub fn new(spi: SPI, dc: DC, width: u16, height: u16) -> Result<Self, DisplayError> {
+        let interface = SPIInterface::new(spi, dc);
+        Ok(Self { interface, width, height })
+    }
+
+    fn set_window(&mut self, area: Rect) -> Result<(), DisplayError> {
+        // simplified set column/row addresses
+        self.interface.send_commands(DataFormat::U8(&[
+            0x2A,
+            (area.x >> 8) as u8,
+            area.x as u8,
+            ((area.x + area.width as i32 - 1) >> 8) as u8,
+            (area.x + area.width as i32 - 1) as u8,
+        ]))?;
+        self.interface.send_commands(DataFormat::U8(&[
+            0x2B,
+            (area.y >> 8) as u8,
+            area.y as u8,
+            ((area.y + area.height as i32 - 1) >> 8) as u8,
+            (area.y + area.height as i32 - 1) as u8,
+        ]))?;
+        self.interface.send_commands(DataFormat::U8(&[0x2C]))
+    }
+}
+
+impl<SPI, DC> DisplayDriver for St7789Display<SPI, DC>
+where
+    SPI: SpiDevice,
+    DC: OutputPin,
+{
+    fn flush(&mut self, area: Rect, colors: &[Color]) {
+        if let Ok(()) = self.set_window(area) {
+            let mut buf: [u8; 2] = [0; 2];
+            for color in colors {
+                buf[0] = ((color.0 as u16 >> 3) << 3 | (color.1 as u16 >> 5)) as u8;
+                buf[1] = ((color.1 as u16 & 0b111_000) << 3 | (color.2 as u16 >> 3)) as u8;
+                let _ = self.interface.send_data(DataFormat::U8(&buf));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a basic ST7789 display driver using `embedded-hal`
- expose the driver behind a new `st7789` feature flag
- complete the input device TODO item for the simulator backend

## Testing
- `cargo check --target x86_64-unknown-linux-gnu --features simulator`
- `cargo check --target x86_64-unknown-linux-gnu --features st7789`
- `cargo check --target x86_64-unknown-linux-gnu`


------
https://chatgpt.com/codex/tasks/task_e_68868656d9888333a284cfdbd8f44248