### PR TITLE
Fix golden_label test formatting

### DIFF
--- a/platform/src/display.rs
+++ b/platform/src/display.rs
@@ -1,6 +1,6 @@
-use rlvgl_core::widget::{Color, Rect};
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
+use rlvgl_core::widget::{Color, Rect};
 
 /// Trait implemented by display drivers
 pub trait DisplayDriver {

--- a/widgets/tests/golden_label.rs
+++ b/widgets/tests/golden_label.rs
@@ -1,7 +1,7 @@
-use rlvgl_widgets::label::Label;
-use rlvgl_core::widget::{Color, Rect, Widget};
-use rlvgl_core::renderer::Renderer;
 use platform::display::{BufferDisplay, DisplayDriver};
+use rlvgl_core::renderer::Renderer;
+use rlvgl_core::widget::{Color, Rect, Widget};
+use rlvgl_widgets::label::Label;
 
 struct DisplayRenderer<'a> {
     display: &'a mut BufferDisplay,
@@ -19,8 +19,18 @@ impl<'a> Renderer for DisplayRenderer<'a> {
 #[test]
 fn label_background_render() {
     let mut display = BufferDisplay::new(10, 10);
-    let mut renderer = DisplayRenderer { display: &mut display };
-    let mut label = Label::new("hi", Rect { x: 0, y: 0, width: 10, height: 10 });
+    let mut renderer = DisplayRenderer {
+        display: &mut display,
+    };
+    let mut label = Label::new(
+        "hi",
+        Rect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        },
+    );
     label.style.bg_color = Color(1, 2, 3);
     label.draw(&mut renderer);
 


### PR DESCRIPTION
## Summary
- reorder imports in display driver and label tests
- format label instantiation for readability

## Testing
- `cargo build --workspace`
- `cargo test --workspace --target x86_64-unknown-linux-gnu`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_6886bdd1c47883338e9b3e8114e8853a