### PR TITLE
Add coverage instrumentation via grcov

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,15 @@ target = "thumbv7em-none-eabihf"
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb"
 
+[env]
+CARGO_INCREMENTAL = "0"
+RUSTFLAGS = "-Zinstrument-coverage"
+LLVM_PROFILE_FILE = "coverage-%p-%m.profraw"
+
+[target.'cfg(all())']
+rustflags = [
+    "-C", "link-dead-code",
+    "-C", "opt-level=0",
+    "-C", "debuginfo=2",
+]
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,19 @@ lvgl/ – C submodule (reference only)
 
 As-built. See ./docs/TODO.md for component-by-component progress.
 
+## Coverage Notes
+
+LLVM coverage is available using `grcov`. Run `make coverage` to build the tests
+with instrumentation and generate an HTML report in `./coverage`. When
+collecting coverage, ensure the following environment variables are set (they're
+also present in `.cargo/config.toml`):
+
+```
+CARGO_INCREMENTAL=0
+RUSTFLAGS="-Zinstrument-coverage"
+LLVM_PROFILE_FILE="coverage-%p-%m.profraw"
+```
+
+Future Codex runs should focus on measurable coverage and use these variables
+when generating tests.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+coverage:
+	cargo test --features std
+	grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o coverage/

--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ lvgl/ – C submodule (reference only)
 ## Status
 
 As-built. See `docs/TODO.md` for component-by-component progress.
+
+## Coverage
+
+LLVM coverage instrumentation is configured via `.cargo/config.toml` and the
+`coverage` target in the `Makefile`. Run `make coverage` to execute the tests
+with instrumentation and generate an HTML report under `./coverage/`.

--- a/codex/startup.sh
+++ b/codex/startup.sh
@@ -21,3 +21,4 @@ git submodule update --init --recursive
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
 rustup component add rust-src llvm-tools-preview
 rustup target add thumbv7em-none-eabihf
+cargo install grcov


### PR DESCRIPTION
## Summary
- enable LLVM coverage instrumentation in `.cargo/config.toml`
- install `grcov` in container startup
- add `coverage` target in new `Makefile`
- document how to run coverage in `README` and `AGENTS`

## Testing
- `cargo test --workspace --target x86_64-unknown-linux-gnu`
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_6886cccf557083338c58cf308fd5ca4b