### PR TITLE
Add descriptive doc comments across modules

### DIFF
--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -1,8 +1,12 @@
-/// Basic UI events used for widgets
+/// Basic UI events used for widgets.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
+    /// Called periodically to advance animations or timers.
     Tick,
+    /// A pointer (mouse or touch) was pressed at the given coordinates.
     PointerDown { x: i32, y: i32 },
+    /// The pointer was released.
     PointerUp { x: i32, y: i32 },
+    /// The pointer moved while still pressed.
     PointerMove { x: i32, y: i32 },
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,10 @@
+//! Core runtime types and utilities for the `rlvgl` UI toolkit.
+//!
+//! This crate exposes the building blocks used by higher level widgets and
+//! platform backends. It is intended to be usable in `no_std` environments and
+//! therefore avoids allocations where possible. Widgets are organised into a
+//! tree of [`WidgetNode`] values which receive [`Event`]s and draw themselves via
+//! a [`Renderer`] implementation.
 #![cfg_attr(not(test), no_std)]
 
 // When running tests, pull in the standard library so the test
@@ -18,14 +25,20 @@ use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
-/// Node in the widget hierarchy
+/// Node in the widget hierarchy.
+///
+/// A `WidgetNode` owns a concrete widget instance and zero or more child nodes.
+/// Events are dispatched depth‑first and drawing occurs in the same order.
+/// This mirrors the behaviour of common retained‑mode UI frameworks.
 pub struct WidgetNode {
     pub widget: Rc<RefCell<dyn widget::Widget>>,
     pub children: Vec<WidgetNode>,
 }
 
 impl WidgetNode {
-    /// Propagate an event to this node and its children
+    /// Propagate an event to this node and its children.
+    ///
+    /// Returns `true` if any widget handled the event.
     pub fn dispatch_event(&mut self, event: &event::Event) -> bool {
         if self.widget.borrow_mut().handle_event(event) {
             return true;
@@ -38,7 +51,7 @@ impl WidgetNode {
         false
     }
 
-    /// Recursively draw the node tree
+    /// Recursively draw this node and all child nodes using the given renderer.
     pub fn draw(&self, renderer: &mut dyn renderer::Renderer) {
         self.widget.borrow().draw(renderer);
         for child in &self.children {

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -1,6 +1,9 @@
 use crate::widget::{Color, Rect};
 
-/// Target-agnostic drawing interface
+/// Target-agnostic drawing interface.
+///
+/// Renderers are supplied to widgets during the draw phase. Implementations
+/// may target a physical display, an off-screen buffer or a simulator window.
 pub trait Renderer {
     fn fill_rect(&mut self, rect: Rect, color: Color);
     fn draw_text(&mut self, position: (i32, i32), text: &str, color: Color);

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -1,3 +1,4 @@
+/// Visual appearance attributes applied to widgets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Style {
     pub bg_color: crate::widget::Color,
@@ -15,6 +16,7 @@ impl Default for Style {
     }
 }
 
+/// Builder pattern for constructing [`Style`] instances.
 pub struct StyleBuilder {
     style: Style,
 }
@@ -26,27 +28,32 @@ impl Default for StyleBuilder {
 }
 
 impl StyleBuilder {
+    /// Create a new builder with [`Style::default`] values.
     pub fn new() -> Self {
         Self {
             style: Style::default(),
         }
     }
 
+    /// Set the background color.
     pub fn bg_color(mut self, color: crate::widget::Color) -> Self {
         self.style.bg_color = color;
         self
     }
 
+    /// Set the border color.
     pub fn border_color(mut self, color: crate::widget::Color) -> Self {
         self.style.border_color = color;
         self
     }
 
+    /// Set the border width in pixels.
     pub fn border_width(mut self, width: u8) -> Self {
         self.style.border_width = width;
         self
     }
 
+    /// Consume the builder and return the constructed [`Style`].
     pub fn build(self) -> Style {
         self.style
     }

--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -1,12 +1,17 @@
 use crate::style::Style;
 use crate::widget::Color;
 
-/// Global theme that can modify widget styles
+/// Global theme that can modify widget styles.
+///
+/// Themes provide a simple hook to set initial colors and other stylistic
+/// properties for widgets. Applications can implement this trait to provide
+/// bespoke looks across the UI.
 pub trait Theme {
+    /// Apply the theme to the provided [`Style`].
     fn apply(&self, style: &mut Style);
 }
 
-/// Simple light theme implementation
+/// Simple light theme implementation.
 pub struct LightTheme;
 
 impl Theme for LightTheme {
@@ -16,7 +21,7 @@ impl Theme for LightTheme {
     }
 }
 
-/// Simple dark theme implementation
+/// Simple dark theme implementation.
 pub struct DarkTheme;
 
 impl Theme for DarkTheme {

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -1,7 +1,10 @@
 use crate::event::Event;
 use crate::renderer::Renderer;
 
-/// Rectangle bounds of a widget
+/// Rectangle bounds of a widget.
+///
+/// Coordinates are relative to the parent widget. Width and height are signed
+/// integers to simplify layout calculations.
 #[derive(Debug, Clone, Copy)]
 pub struct Rect {
     pub x: i32,
@@ -10,14 +13,20 @@ pub struct Rect {
     pub height: i32,
 }
 
-/// RGB color used by the renderer
+/// RGB color used by the renderer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color(pub u8, pub u8, pub u8);
 
-/// Base trait implemented by all widgets
+/// Base trait implemented by all widgets.
+///
+/// A widget is expected to provide its bounds, draw itself using a
+/// [`Renderer`], and optionally handle input [`Event`]s.
 pub trait Widget {
     fn bounds(&self) -> Rect;
     fn draw(&self, renderer: &mut dyn Renderer);
     /// Handle an event and return `true` if it was consumed.
+    ///
+    /// The default implementation for most widgets will simply ignore the
+    /// event and return `false`.
     fn handle_event(&mut self, event: &Event) -> bool;
 }

--- a/platform/src/display.rs
+++ b/platform/src/display.rs
@@ -2,23 +2,23 @@ use alloc::vec;
 use alloc::vec::Vec;
 use rlvgl_core::widget::{Color, Rect};
 
-/// Trait implemented by display drivers
+/// Trait implemented by display drivers.
 pub trait DisplayDriver {
-    /// Flush a rectangular region of pixels to the display
+    /// Flush a rectangular region of pixels to the display.
     fn flush(&mut self, area: Rect, colors: &[Color]);
 
-    /// Optional vertical sync hook
+    /// Optional vertical sync hook.
     fn vsync(&mut self) {}
 }
 
-/// Dummy headless driver used for tests
+/// Dummy headless driver used for tests.
 pub struct DummyDisplay;
 
 impl DisplayDriver for DummyDisplay {
     fn flush(&mut self, _area: Rect, _colors: &[Color]) {}
 }
 
-/// In-memory framebuffer driver for tests and headless rendering
+/// In-memory framebuffer driver for tests and headless rendering.
 pub struct BufferDisplay {
     pub width: usize,
     pub height: usize,
@@ -26,6 +26,7 @@ pub struct BufferDisplay {
 }
 
 impl BufferDisplay {
+    /// Create a framebuffer with the specified dimensions.
     pub fn new(width: usize, height: usize) -> Self {
         Self {
             width,

--- a/platform/src/input.rs
+++ b/platform/src/input.rs
@@ -1,11 +1,11 @@
 use rlvgl_core::event::Event;
 
-/// Trait for input devices such as touchscreens or mice
+/// Trait for input devices such as touchscreens or mice.
 pub trait InputDevice {
     fn poll(&mut self) -> Option<Event>;
 }
 
-/// Dummy input device that yields no events
+/// Dummy input device that yields no events.
 pub struct DummyInput;
 
 impl InputDevice for DummyInput {
@@ -14,5 +14,5 @@ impl InputDevice for DummyInput {
     }
 }
 
-/// Alias used by platform backends for standard events
+/// Alias used by platform backends for standard events.
 pub type InputEvent = Event;

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -1,3 +1,4 @@
+//! Hardware and simulator backends for `rlvgl`.
 #![no_std]
 
 extern crate alloc;

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -12,6 +12,7 @@ use rlvgl_core::{
 };
 
 #[cfg(feature = "simulator")]
+/// Desktop simulator display backed by the `minifb` crate.
 pub struct MinifbDisplay {
     window: Window,
     width: usize,
@@ -23,6 +24,7 @@ pub struct MinifbDisplay {
 
 #[cfg(feature = "simulator")]
 impl MinifbDisplay {
+    /// Create a new window with the given size.
     pub fn new(width: usize, height: usize) -> Self {
         let window = Window::new("rlvgl simulator", width, height, WindowOptions::default())
             .expect("failed to create window");
@@ -37,6 +39,7 @@ impl MinifbDisplay {
         }
     }
 
+    /// Present the internal buffer to the window.
     fn update(&mut self) {
         let _ = self
             .window
@@ -46,6 +49,7 @@ impl MinifbDisplay {
 
 #[cfg(feature = "simulator")]
 impl DisplayDriver for MinifbDisplay {
+    /// Copy a region of pixels into the window buffer.
     fn flush(&mut self, area: Rect, colors: &[Color]) {
         for y in 0..area.height as usize {
             for x in 0..area.width as usize {
@@ -61,6 +65,7 @@ impl DisplayDriver for MinifbDisplay {
 
 #[cfg(feature = "simulator")]
 impl InputDevice for MinifbDisplay {
+    /// Convert window input into [`Event`]s understood by the core runtime.
     fn poll(&mut self) -> Option<Event> {
         let pos = self
             .window

--- a/platform/src/st7789.rs
+++ b/platform/src/st7789.rs
@@ -6,6 +6,7 @@ use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::SpiDevice;
 use rlvgl_core::widget::{Color, Rect};
 
+/// Display driver for the ST7789 LCD controller.
 pub struct St7789Display<SPI, DC> {
     interface: SPIInterface<SPI, DC>,
     width: u16,
@@ -17,6 +18,7 @@ where
     SPI: SpiDevice,
     DC: OutputPin,
 {
+    /// Create a new driver instance.
     pub fn new(spi: SPI, dc: DC, width: u16, height: u16) -> Result<Self, DisplayError> {
         let interface = SPIInterface::new(spi, dc);
         Ok(Self {
@@ -26,6 +28,7 @@ where
         })
     }
 
+    /// Configure the address window for subsequent pixel writes.
     fn set_window(&mut self, area: Rect) -> Result<(), DisplayError> {
         // simplified set column/row addresses
         self.interface.send_commands(DataFormat::U8(&[
@@ -51,6 +54,7 @@ where
     SPI: SpiDevice,
     DC: OutputPin,
 {
+    /// Write a pixel buffer to the display at the given rectangle.
     fn flush(&mut self, area: Rect, colors: &[Color]) {
         if let Ok(()) = self.set_window(area) {
             let mut buf: [u8; 2] = [0; 2];

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -6,12 +6,14 @@ use rlvgl_core::widget::{Rect, Widget};
 use crate::label::Label;
 use rlvgl_core::style::Style;
 
+/// Clickable button widget.
 pub struct Button {
     label: Label,
     on_click: Option<Box<dyn FnMut()>>,
 }
 
 impl Button {
+    /// Create a new button with the provided label text.
     pub fn new(text: impl Into<String>, bounds: Rect) -> Self {
         Self {
             label: Label::new(text, bounds),
@@ -19,18 +21,22 @@ impl Button {
         }
     }
 
+    /// Immutable access to the button's style.
     pub fn style(&self) -> &Style {
         &self.label.style
     }
 
+    /// Mutable access to the button's style.
     pub fn style_mut(&mut self) -> &mut Style {
         &mut self.label.style
     }
 
+    /// Register a callback invoked when the button is released.
     pub fn set_on_click<F: FnMut() + 'static>(&mut self, handler: F) {
         self.on_click = Some(Box::new(handler));
     }
 
+    /// Check if the given coordinates are inside the button's bounds.
     fn inside_bounds(&self, x: i32, y: i32) -> bool {
         let b = self.label.bounds();
         x >= b.x && x < b.x + b.width && y >= b.y && y < b.y + b.height
@@ -46,6 +52,7 @@ impl Widget for Button {
         self.label.draw(renderer);
     }
 
+    /// Delegate pointer events and invoke the click handler when released.
     fn handle_event(&mut self, event: &Event) -> bool {
         match event {
             Event::PointerUp { x, y } if self.inside_bounds(*x, *y) => {

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -4,6 +4,7 @@ use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Color, Rect, Widget};
 
+/// Standard checkbox widget with label text.
 pub struct Checkbox {
     bounds: Rect,
     text: String,
@@ -14,6 +15,7 @@ pub struct Checkbox {
 }
 
 impl Checkbox {
+    /// Create a new checkbox.
     pub fn new(text: impl Into<String>, bounds: Rect) -> Self {
         Self {
             bounds,
@@ -25,10 +27,12 @@ impl Checkbox {
         }
     }
 
+    /// Return whether the checkbox is currently checked.
     pub fn is_checked(&self) -> bool {
         self.checked
     }
 
+    /// Set the checked state programmatically.
     pub fn set_checked(&mut self, value: bool) {
         self.checked = value;
     }
@@ -68,6 +72,7 @@ impl Widget for Checkbox {
         renderer.draw_text(text_pos, &self.text, self.text_color);
     }
 
+    /// Toggle the checked state when clicked.
     fn handle_event(&mut self, event: &Event) -> bool {
         if let Event::PointerUp { x, y } = event {
             let inside = *x >= self.bounds.x

--- a/widgets/src/container.rs
+++ b/widgets/src/container.rs
@@ -3,12 +3,14 @@ use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Rect, Widget};
 
+/// Empty widget used to group child widgets and provide background styling.
 pub struct Container {
     bounds: Rect,
     pub style: Style,
 }
 
 impl Container {
+    /// Create a new container with the specified bounds.
     pub fn new(bounds: Rect) -> Self {
         Self {
             bounds,
@@ -26,6 +28,7 @@ impl Widget for Container {
         renderer.fill_rect(self.bounds, self.style.bg_color);
     }
 
+    /// Containers are currently passive and do not react to events.
     fn handle_event(&mut self, _event: &Event) -> bool {
         false
     }

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -3,6 +3,7 @@ use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Color, Rect, Widget};
 
+/// Display a raw pixel buffer.
 pub struct Image<'a> {
     bounds: Rect,
     pub style: Style,
@@ -12,6 +13,7 @@ pub struct Image<'a> {
 }
 
 impl<'a> Image<'a> {
+    /// Create an image widget backed by a slice of pixels.
     pub fn new(bounds: Rect, width: i32, height: i32, pixels: &'a [Color]) -> Self {
         Self {
             bounds,
@@ -46,6 +48,7 @@ impl<'a> Widget for Image<'a> {
         }
     }
 
+    /// Images are purely visual and do not handle events.
     fn handle_event(&mut self, _event: &Event) -> bool {
         false
     }

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -4,6 +4,7 @@ use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Color, Rect, Widget};
 
+/// Simple text element.
 pub struct Label {
     bounds: Rect,
     text: String,
@@ -12,6 +13,7 @@ pub struct Label {
 }
 
 impl Label {
+    /// Create a new label with the provided text and bounds.
     pub fn new(text: impl Into<String>, bounds: Rect) -> Self {
         Self {
             bounds,

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -1,3 +1,4 @@
+//! Collection of built-in widgets for the `rlvgl` toolkit.
 #![no_std]
 
 extern crate alloc;

--- a/widgets/src/list.rs
+++ b/widgets/src/list.rs
@@ -4,6 +4,7 @@ use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Color, Rect, Widget};
 
+/// Scrollable list of selectable text items.
 pub struct List {
     bounds: Rect,
     pub style: Style,
@@ -13,6 +14,7 @@ pub struct List {
 }
 
 impl List {
+    /// Create an empty list widget.
     pub fn new(bounds: Rect) -> Self {
         Self {
             bounds,
@@ -23,18 +25,22 @@ impl List {
         }
     }
 
+    /// Append an item to the end of the list.
     pub fn add_item(&mut self, text: impl Into<String>) {
         self.items.push(text.into());
     }
 
+    /// Return a slice of all list items.
     pub fn items(&self) -> &[String] {
         &self.items
     }
 
+    /// Index of the currently selected item, if any.
     pub fn selected(&self) -> Option<usize> {
         self.selected
     }
 
+    /// Translate a y coordinate into a list index.
     fn index_at(&self, y: i32) -> Option<usize> {
         let row_height = 16;
         if y < self.bounds.y || y >= self.bounds.y + self.bounds.height {
@@ -73,6 +79,7 @@ impl Widget for List {
         }
     }
 
+    /// Select an item when the pointer is released over it.
     fn handle_event(&mut self, event: &Event) -> bool {
         if let Event::PointerUp { x, y } = event {
             if *x >= self.bounds.x && *x < self.bounds.x + self.bounds.width {

--- a/widgets/src/progress.rs
+++ b/widgets/src/progress.rs
@@ -3,6 +3,7 @@ use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Color, Rect, Widget};
 
+/// Simple progress bar widget.
 pub struct ProgressBar {
     bounds: Rect,
     pub style: Style,
@@ -13,6 +14,7 @@ pub struct ProgressBar {
 }
 
 impl ProgressBar {
+    /// Create a new progress bar with a value range.
     pub fn new(bounds: Rect, min: i32, max: i32) -> Self {
         Self {
             bounds,
@@ -24,14 +26,17 @@ impl ProgressBar {
         }
     }
 
+    /// Current progress value.
     pub fn value(&self) -> i32 {
         self.value
     }
 
+    /// Set the progress value, clamped to the configured range.
     pub fn set_value(&mut self, val: i32) {
         self.value = val.clamp(self.min, self.max);
     }
 
+    /// Convert the current value to a filled width in pixels.
     fn width_from_value(&self) -> i32 {
         let range = self.max - self.min;
         if range == 0 {
@@ -60,6 +65,7 @@ impl Widget for ProgressBar {
         renderer.fill_rect(bar_rect, self.bar_color);
     }
 
+    /// Progress bars are display only and ignore events.
     fn handle_event(&mut self, _event: &Event) -> bool {
         false
     }

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -3,6 +3,7 @@ use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Color, Rect, Widget};
 
+/// Horizontal slider allowing selection of a value within a range.
 pub struct Slider {
     bounds: Rect,
     pub style: Style,
@@ -13,6 +14,7 @@ pub struct Slider {
 }
 
 impl Slider {
+    /// Create a new slider.
     pub fn new(bounds: Rect, min: i32, max: i32) -> Self {
         Self {
             bounds,
@@ -24,14 +26,17 @@ impl Slider {
         }
     }
 
+    /// Current slider value.
     pub fn value(&self) -> i32 {
         self.value
     }
 
+    /// Set the slider value, clamped to the valid range.
     pub fn set_value(&mut self, val: i32) {
         self.value = val.clamp(self.min, self.max);
     }
 
+    /// Convert the current value into a pixel position for the knob.
     fn position_from_value(&self) -> i32 {
         let range = self.max - self.min;
         if range == 0 {
@@ -73,6 +78,7 @@ impl Widget for Slider {
         renderer.fill_rect(knob_rect, self.knob_color);
     }
 
+    /// Update the slider value based on pointer release position.
     fn handle_event(&mut self, event: &Event) -> bool {
         if let Event::PointerUp { x, y } = event {
             if *y >= self.bounds.y


### PR DESCRIPTION
## Summary
- enrich documentation for `core`, `widgets`, and `platform` crates
- describe enums, structs and methods for clarity
- add crate level docs for easier automated generation

## Testing
- `cargo test --target x86_64-unknown-linux-gnu`

------
https://chatgpt.com/codex/tasks/task_e_688758f58f7c83339535b2c1119e0e39