### PR TITLE
Fix workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,22 @@ keywords = ["embedded", "graphics", "ui", "lvgl", "no_std"]
 categories = ["embedded", "gui", "no-std", "graphics"]
 publish = true
 
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+rlvgl-core = { path = "core", default-features = false }
+rlvgl-widgets = { path = "widgets", default-features = false }
+platform = { path = "platform", default-features = false }
+
+[features]
+default = []
+png = ["rlvgl-core/png"]
+jpeg = ["rlvgl-core/jpeg"]
+qrcode = ["rlvgl-core/qrcode"]
+simulator = ["platform/simulator"]
+st7789 = ["platform/st7789"]
+
 [profile.release]
 opt-level = "z"
 lto = true
@@ -22,8 +38,8 @@ panic = "abort"
 strip = true
 
 [profile.dev]
-opt-level = 1            # Faster builds but less optimized
-debug = true             # Keep symbols for simulator debugging
+opt-level = 1
+debug = true
 
 [workspace]
 members = ["core", "platform", "widgets"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+pub use rlvgl_core as core;
+pub use rlvgl_widgets as widgets;
+pub use platform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@
 
 extern crate alloc;
 
+pub use platform;
 pub use rlvgl_core as core;
 pub use rlvgl_widgets as widgets;
-pub use platform;


### PR DESCRIPTION
## Summary
- restore workspace Cargo manifest as a publishable crate
- create a minimal library crate re-exporting subcrates

## Testing
- `cargo test --workspace --target x86_64-unknown-linux-gnu`


------
https://chatgpt.com/codex/tasks/task_e_6887810da7008333b6292f1b85b66aee