### PR TITLE
Fix fmt

### DIFF
--- a/core/src/plugins/qrcode.rs
+++ b/core/src/plugins/qrcode.rs
@@ -1,8 +1,8 @@
 use crate::widget::Color;
 use alloc::vec::Vec;
 use qrcode::{
-    types::{Color as QrColor, QrError},
     QrCode,
+    types::{Color as QrColor, QrError},
 };
 
 pub fn generate(data: &[u8]) -> Result<(Vec<Color>, u32, u32), QrError> {

--- a/core/tests/widget_node.rs
+++ b/core/tests/widget_node.rs
@@ -1,8 +1,8 @@
 use rlvgl_core::{
+    WidgetNode,
     event::Event,
     renderer::Renderer,
     widget::{Color, Rect, Widget},
-    WidgetNode,
 };
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/platform/examples/leak.rs
+++ b/platform/examples/leak.rs
@@ -1,7 +1,7 @@
+use rlvgl_core::WidgetNode;
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Rect, Widget};
-use rlvgl_core::WidgetNode;
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/platform/tests/simulator_window.rs
+++ b/platform/tests/simulator_window.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "simulator")]
-use platform::display::DisplayDriver;
-#[cfg(feature = "simulator")]
 use platform::MinifbDisplay;
+#[cfg(feature = "simulator")]
+use platform::display::DisplayDriver;
 #[cfg(feature = "simulator")]
 use rlvgl_core::widget::{Color, Rect};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@
 
 extern crate alloc;
 
-pub use rlvgl_platform as platform;
 pub use rlvgl_core as core;
+pub use rlvgl_platform as platform;
 pub use rlvgl_widgets as widgets;

--- a/widgets/tests/event_fuzz.rs
+++ b/widgets/tests/event_fuzz.rs
@@ -1,10 +1,10 @@
 use platform::display::{BufferDisplay, DisplayDriver};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use rlvgl_core::{
+    WidgetNode,
     event::Event,
     renderer::Renderer,
     widget::{Color, Rect},
-    WidgetNode,
 };
 use rlvgl_widgets::{button::Button, container::Container};
 use std::cell::RefCell;


### PR DESCRIPTION
## Summary
- fix formatting errors in qrcode plugin
- clean up `WidgetNode` import order in tests and examples
- fix import ordering in simulator window test
- reorder subcrate exports in lib
- update event fuzz test imports

## Testing
- `cargo test -p rlvgl-core --target x86_64-unknown-linux-gnu`

------
https://chatgpt.com/codex/tasks/task_e_6887ca33e7308333ae41733e1dbee9f6