### PR TITLE
Add file headers per agent policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,9 @@ when generating tests.
 Always run `cargo fmt --all` and fix formatting errors before preparing a
 pull request. Verify formatting with `cargo fmt --all -- --check`.
 
+Public APIs must be documented. The `#![deny(missing_docs)]` lint is enabled in
+all crates, so compilation will fail if any public item lacks a meaningful
+docstring. These crates are published to crates.io and require clear
+documentation for users.
+All files must include a descriptive file header summarizing their purpose.
+

--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -1,3 +1,8 @@
+//! Animation primitives such as fades and slides.
+//!
+//! These helpers mirror LVGL's animation system while using safe Rust
+//! abstractions where possible.
+
 use crate::style::Style;
 use crate::widget::{Color, Rect};
 

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -1,12 +1,29 @@
-/// Basic UI events used for widgets.
+//! Basic UI events used for widgets.
+
+/// Event types propagated through the widget tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
     /// Called periodically to advance animations or timers.
     Tick,
     /// A pointer (mouse or touch) was pressed at the given coordinates.
-    PointerDown { x: i32, y: i32 },
+    PointerDown {
+        /// Horizontal coordinate relative to the widget origin.
+        x: i32,
+        /// Vertical coordinate relative to the widget origin.
+        y: i32,
+    },
     /// The pointer was released.
-    PointerUp { x: i32, y: i32 },
+    PointerUp {
+        /// Horizontal coordinate relative to the widget origin.
+        x: i32,
+        /// Vertical coordinate relative to the widget origin.
+        y: i32,
+    },
     /// The pointer moved while still pressed.
-    PointerMove { x: i32, y: i32 },
+    PointerMove {
+        /// Horizontal coordinate relative to the widget origin.
+        x: i32,
+        /// Vertical coordinate relative to the widget origin.
+        y: i32,
+    },
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,7 +69,9 @@ use core::cell::RefCell;
 /// Events are dispatched depth‑first and drawing occurs in the same order.
 /// This mirrors the behaviour of common retained‑mode UI frameworks.
 pub struct WidgetNode {
+    /// The widget instance held by this node.
     pub widget: Rc<RefCell<dyn widget::Widget>>,
+    /// Child nodes that make up this widget's hierarchy.
     pub children: Vec<WidgetNode>,
 }
 

--- a/core/src/plugins/canvas.rs
+++ b/core/src/plugins/canvas.rs
@@ -1,3 +1,4 @@
+//! Canvas wrapper based on `embedded_canvas`.
 use crate::widget::Color;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/core/src/plugins/fatfs.rs
+++ b/core/src/plugins/fatfs.rs
@@ -1,3 +1,4 @@
+//! Utilities for working with FAT filesystem images.
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use fatfs::{FileSystem, FsOptions};

--- a/core/src/plugins/fontdue.rs
+++ b/core/src/plugins/fontdue.rs
@@ -1,3 +1,4 @@
+//! Glyph rasterization using `fontdue`.
 use crate::widget::Color;
 use alloc::vec::Vec;
 use fontdue::{Font, FontError, FontSettings};

--- a/core/src/plugins/gif.rs
+++ b/core/src/plugins/gif.rs
@@ -1,3 +1,4 @@
+//! GIF decoder returning frames.
 use crate::widget::Color;
 use alloc::vec::Vec;
 use gif::{ColorOutput, DecodeOptions, DecodingError, Frame};

--- a/core/src/plugins/jpeg.rs
+++ b/core/src/plugins/jpeg.rs
@@ -1,3 +1,4 @@
+//! JPEG decoder for Color pixel arrays.
 use crate::widget::Color;
 use alloc::vec::Vec;
 use jpeg_decoder::{Decoder, Error, PixelFormat};

--- a/core/src/plugins/lottie.rs
+++ b/core/src/plugins/lottie.rs
@@ -1,3 +1,4 @@
+//! Minimal Lottie animation utilities.
 use dotlottie_rs::fms::{DotLottieError, DotLottieManager, Manifest};
 
 pub fn manifest_from_bytes(data: &[u8]) -> Result<Manifest, DotLottieError> {

--- a/core/src/plugins/mod.rs
+++ b/core/src/plugins/mod.rs
@@ -1,3 +1,5 @@
+//! Feature-gated plugin modules for asset handling.
+
 #[cfg(feature = "canvas")]
 pub mod canvas;
 #[cfg(feature = "fatfs")]

--- a/core/src/plugins/nes.rs
+++ b/core/src/plugins/nes.rs
@@ -1,3 +1,4 @@
+//! Utilities for parsing iNES cartridge headers.
 use alloc::string::String;
 use yane::core::Cartridge;
 

--- a/core/src/plugins/pinyin.rs
+++ b/core/src/plugins/pinyin.rs
@@ -1,3 +1,4 @@
+//! Minimal Pinyin input method dictionary.
 use alloc::vec::Vec;
 
 /// Simplified Pinyin input method that maps Latin pinyin syllables to Chinese

--- a/core/src/plugins/png.rs
+++ b/core/src/plugins/png.rs
@@ -1,3 +1,4 @@
+//! PNG decoder yielding raw color pixels.
 use crate::widget::Color;
 use alloc::vec::Vec;
 use png::{ColorType, Decoder, DecodingError};

--- a/core/src/plugins/qrcode.rs
+++ b/core/src/plugins/qrcode.rs
@@ -1,3 +1,4 @@
+//! Generate QR codes as pixel buffers.
 use crate::widget::Color;
 use alloc::vec::Vec;
 use qrcode::{

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -1,3 +1,8 @@
+//! Rendering interface used by widgets.
+//!
+//! Implementors of this trait can target displays, off-screen buffers or
+//! simulator windows.
+
 use crate::widget::{Color, Rect};
 
 /// Target-agnostic drawing interface.
@@ -5,6 +10,9 @@ use crate::widget::{Color, Rect};
 /// Renderers are supplied to widgets during the draw phase. Implementations
 /// may target a physical display, an off-screen buffer or a simulator window.
 pub trait Renderer {
+    /// Fill the given rectangle with a solid color.
     fn fill_rect(&mut self, rect: Rect, color: Color);
+
+    /// Draw UTF‑8 text starting at the provided position using the color.
     fn draw_text(&mut self, position: (i32, i32), text: &str, color: Color);
 }

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -1,8 +1,13 @@
-/// Visual appearance attributes applied to widgets.
+//! Visual appearance attributes applied to widgets.
+
+/// Collection of styling properties for a widget.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Style {
+    /// Background color of the widget.
     pub bg_color: crate::widget::Color,
+    /// Border color of the widget.
     pub border_color: crate::widget::Color,
+    /// Border width in pixels.
     pub border_width: u8,
 }
 

--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -1,3 +1,5 @@
+//! Theme trait and basic implementations.
+
 use crate::style::Style;
 use crate::widget::Color;
 

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -1,3 +1,5 @@
+//! Basic widget traits and geometry types.
+
 use crate::event::Event;
 use crate::renderer::Renderer;
 
@@ -7,22 +9,35 @@ use crate::renderer::Renderer;
 /// integers to simplify layout calculations.
 #[derive(Debug, Clone, Copy)]
 pub struct Rect {
+    /// X coordinate relative to the parent widget.
     pub x: i32,
+    /// Y coordinate relative to the parent widget.
     pub y: i32,
+    /// Width in pixels.
     pub width: i32,
+    /// Height in pixels.
     pub height: i32,
 }
 
 /// RGB color used by the renderer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Color(pub u8, pub u8, pub u8);
+pub struct Color(
+    /// Red component in the range `0..=255`.
+    pub u8,
+    /// Green component in the range `0..=255`.
+    pub u8,
+    /// Blue component in the range `0..=255`.
+    pub u8,
+);
 
 /// Base trait implemented by all widgets.
 ///
 /// A widget is expected to provide its bounds, draw itself using a
 /// [`Renderer`], and optionally handle input [`Event`]s.
 pub trait Widget {
+    /// Return the area this widget occupies relative to its parent.
     fn bounds(&self) -> Rect;
+    /// Render the widget using the provided [`Renderer`].
     fn draw(&self, renderer: &mut dyn Renderer);
     /// Handle an event and return `true` if it was consumed.
     ///

--- a/core/tests/animation.rs
+++ b/core/tests/animation.rs
@@ -1,3 +1,4 @@
+//! Tests for animation primitives.
 use rlvgl_core::animation::{Fade, Slide, Timeline};
 use rlvgl_core::style::Style;
 use rlvgl_core::widget::{Color, Rect};

--- a/core/tests/style_builder.rs
+++ b/core/tests/style_builder.rs
@@ -1,3 +1,4 @@
+//! Tests for the StyleBuilder API.
 use rlvgl_core::style::{Style, StyleBuilder};
 use rlvgl_core::widget::Color;
 

--- a/core/tests/theme.rs
+++ b/core/tests/theme.rs
@@ -1,3 +1,4 @@
+//! Theme application tests.
 use rlvgl_core::style::Style;
 use rlvgl_core::theme::{DarkTheme, LightTheme, Theme};
 use rlvgl_core::widget::Color;

--- a/core/tests/widget_node.rs
+++ b/core/tests/widget_node.rs
@@ -1,3 +1,4 @@
+//! Tests for the WidgetNode container.
 use rlvgl_core::{
     WidgetNode,
     event::Event,

--- a/platform/examples/leak.rs
+++ b/platform/examples/leak.rs
@@ -1,3 +1,4 @@
+//! Example to detect memory leaks in the widget tree.
 use rlvgl_core::WidgetNode;
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;

--- a/platform/src/display.rs
+++ b/platform/src/display.rs
@@ -1,3 +1,4 @@
+//! Traits and helpers for display drivers.
 use alloc::vec;
 use alloc::vec::Vec;
 use rlvgl_core::widget::{Color, Rect};
@@ -20,8 +21,11 @@ impl DisplayDriver for DummyDisplay {
 
 /// In-memory framebuffer driver for tests and headless rendering.
 pub struct BufferDisplay {
+    /// Width of the framebuffer in pixels.
     pub width: usize,
+    /// Height of the framebuffer in pixels.
     pub height: usize,
+    /// Pixel buffer stored in row-major order.
     pub buffer: Vec<Color>,
 }
 

--- a/platform/src/input.rs
+++ b/platform/src/input.rs
@@ -1,7 +1,9 @@
+//! Abstractions for input devices.
 use rlvgl_core::event::Event;
 
 /// Trait for input devices such as touchscreens or mice.
 pub trait InputDevice {
+    /// Retrieve the next input event if available.
     fn poll(&mut self) -> Option<Event>;
 }
 

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -7,7 +7,9 @@ extern crate alloc;
 #[cfg(feature = "simulator")]
 extern crate std;
 
+/// Display driver traits and implementations.
 pub mod display;
+/// Input device abstractions.
 pub mod input;
 #[cfg(feature = "simulator")]
 pub mod simulator;

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -1,3 +1,4 @@
+//! Simple simulator backend using minifb.
 #[cfg(feature = "simulator")]
 use crate::{display::DisplayDriver, input::InputDevice};
 #[cfg(feature = "simulator")]

--- a/platform/src/st7789.rs
+++ b/platform/src/st7789.rs
@@ -1,3 +1,4 @@
+//! Driver for the ST7789 LCD controller.
 #![cfg(feature = "st7789")]
 use crate::display::DisplayDriver;
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};

--- a/platform/tests/input_device.rs
+++ b/platform/tests/input_device.rs
@@ -1,3 +1,4 @@
+//! Tests for input device implementations.
 use rlvgl_core::event::Event;
 use rlvgl_platform::input::{DummyInput, InputDevice};
 

--- a/platform/tests/leak_detection.rs
+++ b/platform/tests/leak_detection.rs
@@ -1,3 +1,4 @@
+//! Runs the leak example under valgrind.
 use std::process::Command;
 
 #[test]

--- a/platform/tests/simulator_window.rs
+++ b/platform/tests/simulator_window.rs
@@ -1,3 +1,4 @@
+//! Tests for the minifb simulator window.
 #[cfg(feature = "simulator")]
 use rlvgl_core::widget::{Color, Rect};
 #[cfg(feature = "simulator")]

--- a/platform/tests/size_regression.rs
+++ b/platform/tests/size_regression.rs
@@ -1,3 +1,4 @@
+//! Ensures the embedded binary size stays within limits.
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! Public re-export crate for the `rlvgl` ecosystem.
+//!
+//! This crate simply exposes the core runtime, widgets and platform layers in a
+//! single package for convenience when publishing to crates.io.
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
 

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -1,3 +1,4 @@
+//! Interactive button widget with callback support.
 use alloc::{boxed::Box, string::String};
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -1,3 +1,4 @@
+//! Binary checkbox widget.
 use alloc::string::String;
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
@@ -8,8 +9,11 @@ use rlvgl_core::widget::{Color, Rect, Widget};
 pub struct Checkbox {
     bounds: Rect,
     text: String,
+    /// Visual styling for the checkbox box and label.
     pub style: Style,
+    /// Color used when rendering the label text.
     pub text_color: Color,
+    /// Color of the check mark when selected.
     pub check_color: Color,
     checked: bool,
 }

--- a/widgets/src/container.rs
+++ b/widgets/src/container.rs
@@ -1,3 +1,4 @@
+//! Simple container grouping child widgets.
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
@@ -6,6 +7,7 @@ use rlvgl_core::widget::{Rect, Widget};
 /// Empty widget used to group child widgets and provide background styling.
 pub struct Container {
     bounds: Rect,
+    /// Visual style applied to the container background.
     pub style: Style,
 }
 

--- a/widgets/src/image.rs
+++ b/widgets/src/image.rs
@@ -1,3 +1,4 @@
+//! Simple pixel-buffer image widget.
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
@@ -6,6 +7,7 @@ use rlvgl_core::widget::{Color, Rect, Widget};
 /// Display a raw pixel buffer.
 pub struct Image<'a> {
     bounds: Rect,
+    /// Styling for the image background.
     pub style: Style,
     width: i32,
     height: i32,

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -1,3 +1,4 @@
+//! Basic text label.
 use alloc::string::String;
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
@@ -8,7 +9,9 @@ use rlvgl_core::widget::{Color, Rect, Widget};
 pub struct Label {
     bounds: Rect,
     text: String,
+    /// Visual style of the label background.
     pub style: Style,
+    /// Color used to render the text.
     pub text_color: Color,
 }
 

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -4,11 +4,19 @@
 
 extern crate alloc;
 
+/// Clickable button widget.
 pub mod button;
+/// Checkbox widget for boolean options.
 pub mod checkbox;
+/// Container widget for layout grouping.
 pub mod container;
+/// Image display widget.
 pub mod image;
+/// Text label widget.
 pub mod label;
+/// Scrollable list widget.
 pub mod list;
+/// Progress bar widget.
 pub mod progress;
+/// Slider widget for numeric input.
 pub mod slider;

--- a/widgets/src/list.rs
+++ b/widgets/src/list.rs
@@ -1,3 +1,4 @@
+//! Vertical scrolling list of selectable strings.
 use alloc::{string::String, vec::Vec};
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
@@ -7,7 +8,9 @@ use rlvgl_core::widget::{Color, Rect, Widget};
 /// Scrollable list of selectable text items.
 pub struct List {
     bounds: Rect,
+    /// Style used for list items.
     pub style: Style,
+    /// Color for item text.
     pub text_color: Color,
     items: Vec<String>,
     selected: Option<usize>,

--- a/widgets/src/progress.rs
+++ b/widgets/src/progress.rs
@@ -1,3 +1,4 @@
+//! Horizontal progress indicator.
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
@@ -6,7 +7,9 @@ use rlvgl_core::widget::{Color, Rect, Widget};
 /// Simple progress bar widget.
 pub struct ProgressBar {
     bounds: Rect,
+    /// Background and border style of the bar.
     pub style: Style,
+    /// Color of the filled portion representing progress.
     pub bar_color: Color,
     min: i32,
     max: i32,

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -1,3 +1,4 @@
+//! Horizontal slider widget.
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::style::Style;
@@ -6,7 +7,9 @@ use rlvgl_core::widget::{Color, Rect, Widget};
 /// Horizontal slider allowing selection of a value within a range.
 pub struct Slider {
     bounds: Rect,
+    /// Style for the track and background.
     pub style: Style,
+    /// Color of the draggable knob.
     pub knob_color: Color,
     min: i32,
     max: i32,

--- a/widgets/tests/checkbox_event.rs
+++ b/widgets/tests/checkbox_event.rs
@@ -1,3 +1,4 @@
+//! Tests for checkbox event handling.
 use rlvgl_core::{event::Event, widget::Rect, widget::Widget};
 use rlvgl_widgets::checkbox::Checkbox;
 

--- a/widgets/tests/event_fuzz.rs
+++ b/widgets/tests/event_fuzz.rs
@@ -1,3 +1,4 @@
+//! Fuzz tests for random widget events.
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rlvgl_core::{
     WidgetNode,

--- a/widgets/tests/golden_button.rs
+++ b/widgets/tests/golden_button.rs
@@ -1,3 +1,4 @@
+//! Golden tests for button rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/golden_checkbox.rs
+++ b/widgets/tests/golden_checkbox.rs
@@ -1,3 +1,4 @@
+//! Golden tests for checkbox rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/golden_container.rs
+++ b/widgets/tests/golden_container.rs
@@ -1,3 +1,4 @@
+//! Golden tests for container rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/golden_image.rs
+++ b/widgets/tests/golden_image.rs
@@ -1,3 +1,4 @@
+//! Golden tests for image widget rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/golden_label.rs
+++ b/widgets/tests/golden_label.rs
@@ -1,3 +1,4 @@
+//! Golden tests for label rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/golden_list.rs
+++ b/widgets/tests/golden_list.rs
@@ -1,3 +1,4 @@
+//! Golden tests for list widget rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/golden_progress.rs
+++ b/widgets/tests/golden_progress.rs
@@ -1,3 +1,4 @@
+//! Golden tests for progress bar rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/golden_slider.rs
+++ b/widgets/tests/golden_slider.rs
@@ -1,3 +1,4 @@
+//! Golden tests for slider rendering.
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};
 use rlvgl_platform::display::{BufferDisplay, DisplayDriver};

--- a/widgets/tests/layout_stress.rs
+++ b/widgets/tests/layout_stress.rs
@@ -1,3 +1,4 @@
+//! Stress tests for random widget layouts.
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use rlvgl_core::renderer::Renderer;

--- a/widgets/tests/list_draw_selected.rs
+++ b/widgets/tests/list_draw_selected.rs
@@ -1,3 +1,4 @@
+//! Verifies list draws highlight for selected item.
 use rlvgl_core::event::Event;
 use rlvgl_core::renderer::Renderer;
 use rlvgl_core::widget::{Color, Rect, Widget};

--- a/widgets/tests/list_event.rs
+++ b/widgets/tests/list_event.rs
@@ -1,3 +1,4 @@
+//! Tests for list selection events.
 use rlvgl_core::widget::Widget;
 use rlvgl_core::{event::Event, widget::Rect};
 use rlvgl_widgets::list::List;

--- a/widgets/tests/progress_edge.rs
+++ b/widgets/tests/progress_edge.rs
@@ -1,3 +1,4 @@
+//! Tests edge cases for ProgressBar.
 use rlvgl_core::{
     event::Event,
     renderer::Renderer,

--- a/widgets/tests/slider_event.rs
+++ b/widgets/tests/slider_event.rs
@@ -1,3 +1,4 @@
+//! Tests for slider event handling.
 use rlvgl_core::widget::Widget;
 use rlvgl_core::{event::Event, widget::Rect};
 use rlvgl_widgets::slider::Slider;

--- a/widgets/tests/slider_zero_range.rs
+++ b/widgets/tests/slider_zero_range.rs
@@ -1,3 +1,4 @@
+//! Regression tests for zero-range sliders.
 use rlvgl_core::{event::Event, widget::Rect, widget::Widget};
 use rlvgl_widgets::slider::Slider;
 


### PR DESCRIPTION
## Summary
- document required header comment in `AGENTS.md`
- add file header comments for all Rust sources, examples and tests

## Testing
- `cargo fmt --all -- --check`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_688ac047da4c8333887cad5a160416b6