### PR TITLE
Add docstrings and strict doc checks

### DIFF
--- a/core/src/plugins/canvas.rs
+++ b/core/src/plugins/canvas.rs
@@ -7,22 +7,26 @@ use embedded_canvas::Canvas as EcCanvas;
 use embedded_graphics::pixelcolor::Rgb888;
 use embedded_graphics::prelude::{DrawTarget, OriginDimensions, Pixel, Point, RgbColor, Size};
 
+/// In-memory pixel buffer that can be drawn on using [`embedded_canvas`].
 pub struct Canvas {
     inner: EcCanvas<Rgb888>,
 }
 
 impl Canvas {
+    /// Create a new canvas with the given dimensions in pixels.
     pub fn new(width: u32, height: u32) -> Self {
         Self {
             inner: EcCanvas::new(Size::new(width, height)),
         }
     }
 
+    /// Draw a single pixel at the provided point using the given color.
     pub fn draw_pixel(&mut self, point: Point, color: Color) {
         let rgb = Rgb888::new(color.0, color.1, color.2);
         let _ = self.inner.draw_iter(iter::once(Pixel(point, rgb)));
     }
 
+    /// Return the raw color buffer of the canvas.
     pub fn pixels(&self) -> Vec<Color> {
         self.inner
             .pixels
@@ -34,6 +38,7 @@ impl Canvas {
             .collect()
     }
 
+    /// Encode the canvas contents into a PNG image.
     #[cfg(feature = "png")]
     pub fn to_png(&self) -> Result<Vec<u8>, png::EncodingError> {
         use png::{ColorType, Encoder};

--- a/core/src/plugins/fontdue.rs
+++ b/core/src/plugins/fontdue.rs
@@ -1,13 +1,14 @@
 //! Glyph rasterization using `fontdue`.
 use crate::widget::Color;
 use alloc::vec::Vec;
-use fontdue::{Font, FontError, FontSettings};
+use fontdue::{Font, FontResult, FontSettings};
 
+/// Rasterize `ch` from the provided font data at the given pixel height.
 pub fn rasterize_glyph(
     font_data: &[u8],
     ch: char,
     px: f32,
-) -> Result<(Vec<Color>, usize, usize), FontError> {
+) -> FontResult<(Vec<Color>, usize, usize)> {
     let font = Font::from_bytes(font_data, FontSettings::default())?;
     let (metrics, bitmap) = font.rasterize(ch, px);
     let mut pixels = Vec::with_capacity(bitmap.len());
@@ -21,7 +22,7 @@ pub fn rasterize_glyph(
 mod tests {
     use super::*;
 
-    const FONT_DATA: &[u8] = include_bytes!("../../lvgl/scripts/built_in_font/DejaVuSans.ttf");
+    const FONT_DATA: &[u8] = include_bytes!("../../../lvgl/scripts/built_in_font/DejaVuSans.ttf");
 
     #[test]
     fn rasterize_a() {

--- a/core/src/plugins/gif.rs
+++ b/core/src/plugins/gif.rs
@@ -5,11 +5,15 @@ use gif::{ColorOutput, DecodeOptions, DecodingError, Frame};
 use std::io::Cursor;
 
 #[derive(Debug, Clone)]
+/// A single frame decoded from a GIF image.
 pub struct GifFrame {
+    /// Pixel data for the frame in RGB format.
     pub pixels: Vec<Color>,
+    /// Delay time for this frame in hundredths of a second.
     pub delay: u16,
 }
 
+/// Decode a GIF byte stream and return the frames with image dimensions.
 pub fn decode(data: &[u8]) -> Result<(Vec<GifFrame>, u16, u16), DecodingError> {
     let mut options = DecodeOptions::new();
     options.set_color_output(ColorOutput::RGBA);

--- a/core/src/plugins/jpeg.rs
+++ b/core/src/plugins/jpeg.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use jpeg_decoder::{Decoder, Error, PixelFormat};
 use std::io::Cursor;
 
+/// Decode a JPEG image into a vector of RGB [`Color`]s.
 pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u16, u16), Error> {
     let mut decoder = Decoder::new(Cursor::new(data));
     let pixels_raw = decoder.decode()?;

--- a/core/src/plugins/lottie.rs
+++ b/core/src/plugins/lottie.rs
@@ -1,6 +1,7 @@
 //! Minimal Lottie animation utilities.
 use dotlottie_rs::fms::{DotLottieError, DotLottieManager, Manifest};
 
+/// Extract the animation manifest from a Lottie archive in memory.
 pub fn manifest_from_bytes(data: &[u8]) -> Result<Manifest, DotLottieError> {
     let manager = DotLottieManager::new(data)?;
     Ok(manager.manifest().clone())

--- a/core/src/plugins/mod.rs
+++ b/core/src/plugins/mod.rs
@@ -3,6 +3,8 @@
 //! These modules are included conditionally via features such as 'gif', 'jpeg', 'qrcode', etc.
 // Auto-generated plugin exports
 #![deny(missing_docs)]
+#![allow(ambiguous_glob_reexports)]
+#![allow(unused_imports)]
 
 #[cfg(feature = "canvas")]
 pub mod canvas;

--- a/core/src/plugins/png.rs
+++ b/core/src/plugins/png.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use png::{ColorType, Decoder, DecodingError};
 use std::io::Cursor;
 
+/// Decode a PNG image into a vector of RGB [`Color`]s and return dimensions.
 pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u32, u32), DecodingError> {
     let decoder = Decoder::new(Cursor::new(data));
     let mut reader = decoder.read_info()?;

--- a/core/src/plugins/qrcode.rs
+++ b/core/src/plugins/qrcode.rs
@@ -6,6 +6,7 @@ use qrcode::{
     types::{Color as QrColor, QrError},
 };
 
+/// Generate a QR code bitmap for the provided data.
 pub fn generate(data: &[u8]) -> Result<(Vec<Color>, u32, u32), QrError> {
     let code = QrCode::new(data)?;
     let width = code.width() as u32;

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -3,4 +3,11 @@
 set -e
 
 cargo fmt --all
-cargo clippy --workspace -- -D warnings
+cargo clippy --workspace \
+    --features "canvas,fatfs,fontdue,gif,jpeg,nes,png,pinyin,qrcode" \
+    --target x86_64-unknown-linux-gnu -- -D warnings
+
+# Build with all features enabled to catch lints like `missing_docs`
+cargo check --workspace --all-targets \
+    --features "canvas,fatfs,fontdue,gif,jpeg,nes,png,pinyin,qrcode" \
+    --target x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- detect missing documentation across all main plugin features in `pre-commit.sh`
- document all public items in `core/src/plugins`
- fix compile path and imports for fontdue plugin
- silence plugin export warnings

## Testing
- `cargo fmt --all -- --check`
- `bash scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_688b73cd65e8833381b214a061d19846