### PR TITLE
Add Dash Lottie renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The C version of LVGL is included as a git submodule for reference and test vect
 - Component-based module layout (core, widgets, platform)
 - Simulatable via std-enabled feature flag
 - Pluggable display and input backends
+- Optional Lottie parsing via `dotlottie-rs` (std only). Embedded platforms
+  should pre-render frames rather than decode animations at runtime.
 
 ## Project Structure
 - [core](https://github.com/SoftOboros/rlvgl/blob/main/core/README.md)/ – Widget base trait, layout, event dispatch
@@ -27,10 +29,9 @@ The C version of LVGL is included as a git submodule for reference and test vect
 - [platform](https://github.com/SoftOboros/rlvgl/blob/main/platform/platform/README.md)/ – Display/input traits and HAL adapters
 - [support](https://github.com/SoftOboros/rlvgl/blob/main/support/README.md)/ – Fonts, geometry, style, color utils
 - [lvgl](https://github.com/lvgl/lvgl/blob/master/README.md)/ – C submodule (reference only)
-git pul
 ## Status
 
-As-built. See  for component-by-component progress.
+As-built. See [TODO](https://github.com/SoftOboros/rlvgl/blob/main/docs/TODO.md) for component-by-component progress.
 - [TODO](https://github.com/SoftOboros/rlvgl/blob/main/docs/TODO.md)
 - [TEST-TODO](https://github.com/SoftOboros/rlvgl/blob/main/docs/TEST-TODO.md)
 - [TODO-PLUGINS](https://github.com/SoftOboros/rlvgl/blob/main/docs/TODO-PLUGINS.md)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,6 +57,12 @@ pub use plugins::jpeg;
 
 #[cfg(feature = "lottie")]
 #[cfg_attr(docsrs, doc(cfg(feature = "lottie")))]
+pub use plugins::dash_lottie;
+#[cfg(feature = "lottie")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lottie")))]
+pub use plugins::dash_lottie_render;
+#[cfg(feature = "lottie")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lottie")))]
 pub use plugins::lottie;
 
 #[cfg(feature = "nes")]
@@ -64,7 +70,7 @@ pub use plugins::lottie;
 pub use plugins::nes;
 
 #[cfg(feature = "pinyin")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pinyan")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "pinyin")))]
 pub use plugins::pinyin;
 
 #[cfg(feature = "png")]

--- a/core/src/plugins/dash_lottie.rs
+++ b/core/src/plugins/dash_lottie.rs
@@ -1,0 +1,122 @@
+//! Dash Lottie player for pre-rendered keyframes.
+//!
+//! This decoder reads a minimal binary format consisting of a header
+//! followed by raw RGB frames. It avoids `dotlottie-rs` at runtime and
+//! is suitable for `no_std` embedded targets.
+
+use crate::widget::Color;
+use alloc::vec::Vec;
+
+/// A single pre-rendered animation frame.
+#[derive(Debug, Clone)]
+pub struct DashFrame {
+    /// RGB pixel data for the frame.
+    pub pixels: Vec<Color>,
+    /// Display time for this frame in milliseconds.
+    pub delay: u16,
+}
+
+/// Pre-rendered animation containing all frames.
+#[derive(Debug, Clone)]
+pub struct DashAnimation {
+    /// Frame pixels and delays.
+    pub frames: Vec<DashFrame>,
+    /// Width of each frame in pixels.
+    pub width: u16,
+    /// Height of each frame in pixels.
+    pub height: u16,
+}
+
+/// Decode a Dash Lottie keyframe file.
+///
+/// The binary layout is:
+/// ```text
+/// u16 width, u16 height, u16 frame_count,
+///   [ u16 delay_ms, width*height*3 bytes RGB pixels ] * frame_count
+/// ```
+pub fn load(data: &[u8]) -> Result<DashAnimation, &'static str> {
+    if data.len() < 6 {
+        return Err("data too short");
+    }
+    let width = u16::from_be_bytes([data[0], data[1]]);
+    let height = u16::from_be_bytes([data[2], data[3]]);
+    let frame_count = u16::from_be_bytes([data[4], data[5]]);
+    let mut offset = 6;
+    let mut frames = Vec::with_capacity(frame_count as usize);
+    for _ in 0..frame_count {
+        if offset + 2 > data.len() {
+            return Err("truncated frame header");
+        }
+        let delay = u16::from_be_bytes([data[offset], data[offset + 1]]);
+        offset += 2;
+        let pixel_bytes = width as usize * height as usize * 3;
+        if offset + pixel_bytes > data.len() {
+            return Err("truncated frame data");
+        }
+        let mut pixels = Vec::with_capacity(width as usize * height as usize);
+        for chunk in data[offset..offset + pixel_bytes].chunks_exact(3) {
+            pixels.push(Color(chunk[0], chunk[1], chunk[2]));
+        }
+        offset += pixel_bytes;
+        frames.push(DashFrame { pixels, delay });
+    }
+    Ok(DashAnimation {
+        frames,
+        width,
+        height,
+    })
+}
+
+/// Encode a [`DashAnimation`] into the binary keyframe format.
+pub fn encode(anim: &DashAnimation) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&anim.width.to_be_bytes());
+    out.extend_from_slice(&anim.height.to_be_bytes());
+    out.extend_from_slice(&(anim.frames.len() as u16).to_be_bytes());
+    for frame in &anim.frames {
+        out.extend_from_slice(&frame.delay.to_be_bytes());
+        for color in &frame.pixels {
+            out.push(color.0);
+            out.push(color.1);
+            out.push(color.2);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    const SAMPLE_B64: &str = "AAEAAQACAGT/AAAAZAD/AA==";
+
+    #[test]
+    fn decode_sample() {
+        let data = base64::engine::general_purpose::STANDARD
+            .decode(SAMPLE_B64)
+            .unwrap();
+        let anim = load(&data).unwrap();
+        assert_eq!(anim.width, 1);
+        assert_eq!(anim.height, 1);
+        assert_eq!(anim.frames.len(), 2);
+        assert_eq!(anim.frames[0].pixels[0], Color(255, 0, 0));
+        assert_eq!(anim.frames[1].pixels[0], Color(0, 255, 0));
+    }
+
+    #[test]
+    fn encode_roundtrip() {
+        let anim = DashAnimation {
+            frames: vec![DashFrame {
+                pixels: vec![Color(1, 2, 3)],
+                delay: 10,
+            }],
+            width: 1,
+            height: 1,
+        };
+        let bytes = encode(&anim);
+        let decoded = load(&bytes).unwrap();
+        assert_eq!(decoded.frames[0].pixels[0], Color(1, 2, 3));
+        assert_eq!(decoded.frames[0].delay, 10);
+    }
+}

--- a/core/src/plugins/dash_lottie_render.rs
+++ b/core/src/plugins/dash_lottie_render.rs
@@ -1,0 +1,87 @@
+//! Dash Lottie renderer producing pre-rendered keyframes.
+//!
+//! Uses `dotlottie-rs` to decode a `.lottie` archive and render
+//! each frame with ThorVG. Intended for desktop or build-time use
+//! to generate the lightweight keyframe format consumed by the
+//! [`dash_lottie::load`] player.
+
+use crate::plugins::dash_lottie::{DashAnimation, DashFrame, encode};
+use crate::widget::Color;
+use alloc::vec::Vec;
+use dotlottie_rs::fms::DotLottieError;
+use dotlottie_rs::{Config, DotLottiePlayer};
+
+/// Render a dotLottie archive into a DashAnimation.
+///
+/// `width` and `height` control the output resolution regardless of
+/// the animation's intrinsic size.
+pub fn render_dotlottie_to_animation(
+    data: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<DashAnimation, DotLottieError> {
+    let player = DotLottiePlayer::new(Config {
+        autoplay: false,
+        use_frame_interpolation: false,
+        ..Config::default()
+    });
+    if !player.load_dotlottie_data(data, width, height) {
+        return Err(DotLottieError::ManifestNotFound);
+    }
+    let total = player.total_frames() as u16;
+    let duration = player.duration();
+    let delay = if total > 0 && duration > 0.0 {
+        (duration * 1000.0 / f32::from(total)).round() as u16
+    } else {
+        0
+    };
+    let mut frames = Vec::with_capacity(total as usize);
+    while !player.is_complete() {
+        let next = player.request_frame();
+        if player.set_frame(next) {
+            player.render();
+            let mut pixels = Vec::with_capacity((width * height) as usize);
+            for &px in player.buffer() {
+                let r = (px & 0xFF) as u8;
+                let g = ((px >> 8) & 0xFF) as u8;
+                let b = ((px >> 16) & 0xFF) as u8;
+                pixels.push(Color(r, g, b));
+            }
+            frames.push(DashFrame { pixels, delay });
+        }
+    }
+    Ok(DashAnimation {
+        frames,
+        width: width as u16,
+        height: height as u16,
+    })
+}
+
+/// Convenience helper that renders a dotLottie archive and returns the
+/// encoded Dash keyframe binary.
+pub fn render_dotlottie_to_bytes(
+    data: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, DotLottieError> {
+    let anim = render_dotlottie_to_animation(data, width, height)?;
+    Ok(encode(&anim))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    const SIMPLE_LOTTIE: &str = "UEsDBBQAAAAIAGit/VrKjHKDLgAAADEAAAANAAAAbWFuaWZlc3QuanNvbqtWSszLzE0syczPK1ayUoiuVspMAdJKGak5OflKtbE6CkplqUXFQGmQqKFSLQBQSwMEFAAAAAgAaK39Wn3redEyAAAAOQAAABUAAABhbmltYXRpb25zL2hlbGxvLmpzb26rVipTslIy1TNX0lFKK1KyMjbQUcosULICUvkQqlzJylBHKQNM5iRWphYVK1lFx9YCAFBLAQIUAxQAAAAIAGit/VrKjHKDLgAAADEAAAANAAAAAAAAAAAAAACAAQAAAABtYW5pZmVzdC5qc29uUEsBAhQDFAAAAAgAaK39Wn3redEyAAAAOQAAABUAAAAAAAAAAAAAAIABWQAAAGFuaW1hdGlvbnMvaGVsbG8uanNvblBLBQYAAAAAAgACAH4AAAC+AAAAAAA=";
+
+    #[test]
+    fn render_sample() {
+        let data = base64::engine::general_purpose::STANDARD
+            .decode(SIMPLE_LOTTIE)
+            .unwrap();
+        let bytes = render_dotlottie_to_bytes(&data, 1, 1).unwrap();
+        // at least header
+        assert!(bytes.len() >= 6);
+    }
+}

--- a/core/src/plugins/lottie.rs
+++ b/core/src/plugins/lottie.rs
@@ -1,4 +1,9 @@
 //! Minimal Lottie animation utilities.
+//!
+//! **Note:** `dotlottie-rs` pulls in heavy dependencies and uses a `build.rs`
+//! script which is undesirable for `no_std` targets. Embedded platforms should
+//! pre-render animations and stream keyframes instead of decoding Lottie files
+//! at runtime.
 use dotlottie_rs::fms::{DotLottieError, DotLottieManager, Manifest};
 
 /// Extract the animation manifest from a Lottie archive in memory.

--- a/core/src/plugins/mod.rs
+++ b/core/src/plugins/mod.rs
@@ -32,6 +32,14 @@ pub use jpeg::*;
 pub mod lottie;
 #[cfg(feature = "lottie")]
 pub use lottie::*;
+#[cfg(feature = "lottie")]
+pub mod dash_lottie;
+#[cfg(feature = "lottie")]
+pub use dash_lottie::*;
+#[cfg(feature = "lottie")]
+pub mod dash_lottie_render;
+#[cfg(feature = "lottie")]
+pub use dash_lottie_render::*;
 
 #[cfg(feature = "nes")]
 pub mod nes;

--- a/docs/TODO-PLUGINS.md
+++ b/docs/TODO-PLUGINS.md
@@ -104,11 +104,13 @@ matrix:
 
 | ✔︎  | Component                         | Rust crate / source                                | Task(s)                                                                                                                | Depends on |
 | --- | --------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------- |
-| [x] | **Lottie / dotLottie animations** | `dotlottie-rs` (player) citeturn236649155616415 | • Evaluate WASM/thorvg backend footprint.• Expose `LottiePlayer` widget.• Might need feature gate `lottie` (std-only). | GIF, Font  |
+| [x] | **Lottie / dotLottie animations** | `dotlottie-rs` (player) citeturn236649155616415 | • Evaluate WASM/thorvg backend footprint.• Expose `LottiePlayer` widget.• **For embedded targets, pre-render keyframes in the platform instead of decoding with `dotlottie-rs`.** | GIF, Font  |
 | [x] | **Sketchpad / Canvas widget**     | `embedded-canvas` citeturn184290798726883       | • Add `CanvasWidget` integrating pan/zoom.• Provide to-PNG export using PNG feature.                                   | PNG        |
 | [x] | **IME – Pinyin support**          | `pinyin` crate citeturn137135872219639          | • Build `PinyinInputMethod` service.• Hook into TextField once implemented.                                            | Font       |
 | [x] | **File-explorer (SD/FAT)**        | `fatfs-embedded` citeturn791986641516626        | • Implement `BlockDevice` for target flash/SD.• Add `FilePicker` widget demo.                                          | Canvas     |
 | [x] | **Example cartridge (NES)**       | `yane` crate citeturn794589435371464            | • Optional showcase app; embed emulator surface via `CanvasWidget`.• Demonstrates real-time framebuffer streaming.     | Canvas     |
+| [x] | **Dash Lottie player**            | stand-alone                   | • standalone Dash Lottie player (rendered Lottie key files)                                           | Lottie     |
+| [x] | **Dash Lottie renderer**          | `dotlottie-rs`                | • dotlottie-rs-based renderer to create its keyframes (rendered files)                              | Lottie     |
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,10 @@ extern crate alloc;
 pub use rlvgl_core as core;
 #[cfg(feature = "canvas")]
 pub use rlvgl_core::canvas;
+#[cfg(feature = "lottie")]
+pub use rlvgl_core::dash_lottie;
+#[cfg(feature = "lottie")]
+pub use rlvgl_core::dash_lottie_render;
 #[cfg(feature = "fatfs")]
 pub use rlvgl_core::fatfs;
 #[cfg(feature = "fontdue")]


### PR DESCRIPTION
## Summary
- implement `dash_lottie_render` using dotlottie-rs
- encode `DashAnimation` back to bytes
- export renderer from plugin modules
- mark Dash Lottie tasks complete in the plugin roadmap
- fix README typos

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p rlvgl-core --target x86_64-unknown-linux-gnu --quiet`
- `cargo test -p rlvgl-core --features lottie --target x86_64-unknown-linux-gnu --quiet` *(fails due to Conan network fetch)*
- `make coverage` *(fails: grcov not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b999325f483339875e1b309c413f6