### PR TITLE
Add APNG decoder plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ optional = true
 version = "1"
 default-features = false
 optional = true
+[dependencies.image]
+version = "0.25"
+default-features = false
+features = ["png"]
+optional = true
 
 [features]
 default = []
@@ -69,6 +74,7 @@ canvas = ["rlvgl-core/canvas", "dep:embedded-canvas", "dep:embedded-graphics"]
 pinyin = ["rlvgl-core/pinyin"]
 fatfs = ["rlvgl-core/fatfs", "dep:fatfs", "dep:fscommon"]
 nes = ["rlvgl-core/nes", "dep:yane"]
+apng = ["rlvgl-core/apng", "dep:image"]
 
 [profile.release]
 opt-level = "z"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,7 @@ embedded-graphics = { version = "0.8", optional = true }
 fatfs = { version = "0.3", optional = true }
 fscommon = { version = "0.1", optional = true }
 yane = { version = "1", default-features = false, optional = true }
+image = { version = "0.25", default-features = false, features = ["png"], optional = true }
 
 [features]
 default = []
@@ -39,11 +40,14 @@ canvas = ["dep:embedded-canvas", "dep:embedded-graphics"]
 pinyin = []
 fatfs = ["dep:fatfs", "dep:fscommon"]
 nes = ["dep:yane"]
+apng = ["dep:image"]
 
 [dev-dependencies]
 rlvgl-widgets = { path = "../widgets" }
 doc-comment = "0.3"
 base64 = "0.22"
+apng = "0.3"
+png = "0.17.7"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,7 +21,8 @@
     feature = "lottie",
     feature = "pinyin",
     feature = "fatfs",
-    feature = "nes"
+    feature = "nes",
+    feature = "apng"
 ))]
 extern crate std;
 
@@ -50,6 +51,10 @@ pub use plugins::fontdue;
 #[cfg(feature = "gif")]
 #[cfg_attr(docsrs, doc(cfg(feature = "gif")))]
 pub use plugins::gif;
+
+#[cfg(feature = "apng")]
+#[cfg_attr(docsrs, doc(cfg(feature = "apng")))]
+pub use plugins::apng;
 
 #[cfg(feature = "jpeg")]
 #[cfg_attr(docsrs, doc(cfg(feature = "jpeg")))]

--- a/core/src/plugins/apng.rs
+++ b/core/src/plugins/apng.rs
@@ -1,0 +1,75 @@
+//! APNG decoder returning frames.
+use crate::widget::Color;
+use alloc::vec::Vec;
+use image::{AnimationDecoder, ImageDecoder, ImageError, codecs::png::PngDecoder};
+use std::io::Cursor;
+
+/// A single frame decoded from an APNG image.
+#[derive(Debug, Clone)]
+pub struct ApngFrame {
+    /// Pixel data for the frame in RGB format.
+    pub pixels: Vec<Color>,
+    /// Delay time for this frame in hundredths of a second.
+    pub delay: u16,
+}
+
+/// Decode an APNG byte stream and return the frames with image dimensions.
+pub fn decode(data: &[u8]) -> Result<(Vec<ApngFrame>, u32, u32), ImageError> {
+    let decoder = PngDecoder::new(Cursor::new(data))?;
+    let (width, height) = decoder.dimensions();
+    let apng = decoder.apng()?;
+    let mut frames_out = Vec::new();
+    for frame_res in apng.into_frames() {
+        let frame = frame_res?;
+        let (numer, denom) = frame.delay().numer_denom_ms();
+        let delay_ms = if denom == 0 { 0 } else { numer / denom };
+        let buffer = frame.into_buffer();
+        let mut pixels = Vec::with_capacity((width * height) as usize);
+        for chunk in buffer.into_raw().chunks_exact(4) {
+            pixels.push(Color(chunk[0], chunk[1], chunk[2]));
+        }
+        frames_out.push(ApngFrame {
+            pixels,
+            delay: (delay_ms / 10) as u16,
+        });
+    }
+    Ok((frames_out, width, height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use apng::{Encoder, Frame as ApngFrameInfo, PNGImage, create_config};
+    use png::{BitDepth, ColorType};
+
+    #[test]
+    fn decode_two_frames() {
+        let img1 = PNGImage {
+            width: 1,
+            height: 1,
+            data: vec![255, 0, 0, 255],
+            color_type: ColorType::Rgba,
+            bit_depth: BitDepth::Eight,
+        };
+        let img2 = PNGImage {
+            width: 1,
+            height: 1,
+            data: vec![0, 255, 0, 255],
+            color_type: ColorType::Rgba,
+            bit_depth: BitDepth::Eight,
+        };
+        let cfg = create_config(&vec![img1.clone(), img2.clone()], Some(1)).unwrap();
+        let mut data = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut data, cfg).unwrap();
+            enc.write_frame(&img1, ApngFrameInfo::default()).unwrap();
+            enc.write_frame(&img2, ApngFrameInfo::default()).unwrap();
+            enc.finish_encode().unwrap();
+        }
+        let (frames, w, h) = decode(&data).unwrap();
+        assert_eq!((w, h), (1, 1));
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].pixels[0], Color(255, 0, 0));
+        assert_eq!(frames[1].pixels[0], Color(0, 255, 0));
+    }
+}

--- a/core/src/plugins/mod.rs
+++ b/core/src/plugins/mod.rs
@@ -23,6 +23,11 @@ pub mod gif;
 #[cfg(feature = "gif")]
 pub use gif::*;
 
+#[cfg(feature = "apng")]
+pub mod apng;
+#[cfg(feature = "apng")]
+pub use apng::*;
+
 #[cfg(feature = "jpeg")]
 pub mod jpeg;
 #[cfg(feature = "jpeg")]

--- a/docs/TODO-PLUGINS.md
+++ b/docs/TODO-PLUGINS.md
@@ -95,7 +95,7 @@ matrix:
 | [x] | **GIF animation**           | `gif` crate citeturn764961070150154                       | • Streaming frame decoder into `ImageRaw`.• Expose `Image::play()` widget util.• Needs timer tick integration.                               | PNG        |
 | [x] | **QR-code generator**       | `qrcode` crate citeturn811324940056358                    | • Wrap `QrCode::new()` → bitmap.• Provide `QrWidget` using embedded-graphics draw-target.                                                    | PNG        |
 | [x] | **Dynamic font rasteriser** | `fontdue` (no\_std) or `rusttype` citeturn451122131593768 | • Select crate (pref `fontdue`).• Create `FontProvider` trait.• Replace stub bitmap fonts in Label/Text. |  FONTDUE                        | 
-| [ ] | **APNG Decoder** | `apng` crate | • Create `apng` trait / devoder feature. | APNG
+| [x] | **APNG Decoder** | `apng` crate | • Create `apng` trait / devoder feature. | APNG
 
 --
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 extern crate alloc;
 
 pub use rlvgl_core as core;
+#[cfg(feature = "apng")]
+pub use rlvgl_core::apng;
 #[cfg(feature = "canvas")]
 pub use rlvgl_core::canvas;
 #[cfg(feature = "lottie")]


### PR DESCRIPTION
## Summary
- implement `apng` plugin with `image` crate
- enable optional `apng` feature in crates
- generate APNG frames in unit test
- mark APNG decoder as complete in plugin TODO

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all --features apng --target x86_64-unknown-linux-gnu`

------
https://chatgpt.com/codex/tasks/task_e_688d0563c56483338aaf2b023971cb20