### PR TITLE
Add simulator sample and TODO entries

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -62,3 +62,7 @@ This document tracks the high-level work streams and tasks for rlvgl development
 - [ ] Render same UI in rlvgl, image-diff in CI
 - [ ] Fuzz events (rapid taps, drags) to catch borrow/lifetime panics
 
+## 10 Simulator examples
+- [ ] Update samples/sim (rlvds-sim) to run rlvds in a window using std and the "simulator" feature
+- [ ] Demonstrate core / widget features in examples/sim (use placeholder assets) using hierarchy matching the upper package
+- [ ] Demonstrate plugin features (use placeholder assets) using hierarchy matching the upper package

--- a/examples/sim/Cargo.toml
+++ b/examples/sim/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rlvgl-sim"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+# Currently empty; examples will depend on core crates directly.

--- a/examples/sim/src/lib.rs
+++ b/examples/sim/src/lib.rs
@@ -1,0 +1,5 @@
+//! Helpers for rlvgl simulator examples.
+#![no_std]
+
+/// Placeholder function to ensure the crate builds.
+pub fn init() {}

--- a/samples/sim/Cargo.toml
+++ b/samples/sim/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rlvds-sim"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+rlvgl = { path = "../..", default-features = false, features = ["simulator"] }
+
+[workspace]
+

--- a/samples/sim/src/main.rs
+++ b/samples/sim/src/main.rs
@@ -1,0 +1,17 @@
+//! Runs the rlvgl simulator in a desktop window.
+use rlvgl::core::widget::{Color, Rect};
+use rlvgl::platform::{display::DisplayDriver, input::InputDevice, MinifbDisplay};
+
+fn main() {
+    // Create a small simulator window.
+    let mut display = MinifbDisplay::new(64, 64);
+    let area = Rect { x: 0, y: 0, width: 64, height: 64 };
+    let colors = vec![Color(0, 0, 0); (area.width * area.height) as usize];
+
+    // Render a few frames to demonstrate the simulator.
+    for _ in 0..60 {
+        display.flush(area, &colors);
+        let _ = display.poll();
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}


### PR DESCRIPTION
## Summary
- track planned simulator and plugin examples
- add stub crate for shared simulator helpers
- add rlvds-sim sample that opens a Minifb window via the simulator feature

## Testing
- `./scripts/pre-commit.sh` *(fails: Unable to find rlottie: pkg-config exited with status code 1)*

------
https://chatgpt.com/codex/tasks/task_e_688e0b70dc888333b2f7780985479e7d