### PR TITLE
Use run-based PixelsDisplay API in simulator example

### DIFF
--- a/examples/sim/main.rs
+++ b/examples/sim/main.rs
@@ -1,20 +1,13 @@
 //! Runs the rlvgl simulator in a desktop window.
-use rlvgl::core::widget::{Color, Rect};
-use rlvgl::platform::{display::DisplayDriver, input::InputDevice, PixelsDisplay};
+use rlvgl::platform::PixelsDisplay;
 
 const WIDTH: usize = 320;
 const HEIGHT: usize = 240;
 
 fn main() {
-    // Create a small simulator window.
-    let mut display = PixelsDisplay::new(WIDTH, HEIGHT);
-    let area = Rect { x: 0, y: 0, width: WIDTH as i32, height: HEIGHT as i32 };
-    let colors = vec![Color(0, 0, 0); (area.width * area.height) as usize];
-
-    // Render a few frames to demonstrate the simulator.
-    for _ in 0..60 {
-        display.flush(area, &colors);
-        let _ = display.poll();
-        std::thread::sleep(std::time::Duration::from_millis(16));
-    }
+    PixelsDisplay::new(WIDTH, HEIGHT).run(|frame| {
+        for pixel in frame.chunks_exact_mut(4) {
+            pixel.copy_from_slice(&[0x00, 0x00, 0x00, 0xff]);
+        }
+    });
 }


### PR DESCRIPTION
## Summary
- Update the simulator example to use `PixelsDisplay::run` instead of manual flush/poll calls

## Testing
- `cargo fmt --all` *(fails: file `/workspace/rlvgl/platform/examples/sim/main.rs` does not exist)*
- `cargo fmt --all -- --check` *(fails: file `/workspace/rlvgl/platform/examples/sim/main.rs` does not exist)*
- `./scripts/pre-commit.sh` *(fails: file `/workspace/rlvgl/platform/examples/sim/main.rs` does not exist)*
- `cargo build -p rlvgl-sim`
- `cargo test -p rlvgl-sim`


------
https://chatgpt.com/codex/tasks/task_e_688e6ba034cc8333b3053006bdc1a5f5