### PR TITLE
feat(sim): map winit input to rlvgl events

### DIFF
--- a/examples/sim/main.rs
+++ b/examples/sim/main.rs
@@ -1,13 +1,18 @@
 //! Runs the rlvgl simulator in a desktop window.
-use rlvgl::platform::PixelsDisplay;
+use rlvgl::platform::{InputEvent, PixelsDisplay};
 
 const WIDTH: usize = 320;
 const HEIGHT: usize = 240;
 
 fn main() {
-    PixelsDisplay::new(WIDTH, HEIGHT).run(|frame| {
-        for pixel in frame.chunks_exact_mut(4) {
-            pixel.copy_from_slice(&[0x00, 0x00, 0x00, 0xff]);
-        }
-    });
+    PixelsDisplay::new(WIDTH, HEIGHT).run(
+        |frame| {
+            for pixel in frame.chunks_exact_mut(4) {
+                pixel.copy_from_slice(&[0x00, 0x00, 0x00, 0xff]);
+            }
+        },
+        |evt: InputEvent| {
+            println!("{:?}", evt);
+        },
+    );
 }

--- a/samples/sim/src/main.rs
+++ b/samples/sim/src/main.rs
@@ -1,10 +1,13 @@
 //! Runs the rlvgl simulator in a desktop window.
-use rlvgl::platform::PixelsDisplay;
+use rlvgl::platform::{InputEvent, PixelsDisplay};
 
 fn main() {
-    PixelsDisplay::new(64, 64).run(|frame| {
-        for pixel in frame.chunks_exact_mut(4) {
-            pixel.copy_from_slice(&[0x00, 0x00, 0x00, 0xff]);
-        }
-    });
+    PixelsDisplay::new(64, 64).run(
+        |frame| {
+            for pixel in frame.chunks_exact_mut(4) {
+                pixel.copy_from_slice(&[0x00, 0x00, 0x00, 0xff]);
+            }
+        },
+        |_evt: InputEvent| {},
+    );
 }


### PR DESCRIPTION
## Summary
- translate winit mouse events into `rlvgl` input events
- expose event callback in simulator examples

## Testing
- `cargo fmt --all`
- `./scripts/pre-commit.sh` *(fails: Unable to find rlottie)*


------
https://chatgpt.com/codex/tasks/task_e_688e9a7f4ce883338bfc930e9a609a24