### PR TITLE
Display button click count and route simulator input

### DIFF
--- a/examples/sim/src/lib.rs
+++ b/examples/sim/src/lib.rs
@@ -7,7 +7,7 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, rc::Rc, vec::Vec};
+use alloc::{boxed::Box, format, rc::Rc, vec::Vec};
 use core::cell::RefCell;
 
 use embedded_graphics::{
@@ -29,20 +29,25 @@ use rlvgl::widgets::{button::Button, container::Container, image::Image, label::
 /// button is clicked.
 pub fn build_demo() -> (WidgetNode, Rc<RefCell<u32>>) {
     let click_count = Rc::new(RefCell::new(0));
-    let counter = click_count.clone();
 
-    let mut button = Button::new(
-        "Click",
+    let button = Rc::new(RefCell::new(Button::new(
+        "Clicks: 0",
         Rect {
             x: 10,
             y: 40,
             width: 80,
             height: 20,
         },
-    );
-    button.set_on_click(move || {
-        *counter.borrow_mut() += 1;
-    });
+    )));
+
+    {
+        let counter = click_count.clone();
+        button.borrow_mut().set_on_click(move |btn: &mut Button| {
+            let mut count = counter.borrow_mut();
+            *count += 1;
+            btn.set_text(format!("Clicks: {}", *count));
+        });
+    }
 
     let mut root = WidgetNode {
         widget: Rc::new(RefCell::new(Container::new(Rect {
@@ -68,7 +73,7 @@ pub fn build_demo() -> (WidgetNode, Rc<RefCell<u32>>) {
         children: Vec::new(),
     });
     root.children.push(WidgetNode {
-        widget: Rc::new(RefCell::new(button)),
+        widget: button.clone(),
         children: Vec::new(),
     });
 

--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -1,6 +1,5 @@
 //! Runs the rlvgl simulator with demonstrations of core widgets and plugin features.
-use rlvgl::core::event::Event;
-use rlvgl::platform::PixelsDisplay;
+use rlvgl::platform::{InputEvent, PixelsDisplay};
 use rlvgl_sim::{PixelsRenderer, build_demo, build_plugin_demo};
 use std::{cell::RefCell, rc::Rc};
 
@@ -20,7 +19,7 @@ fn main() {
                 root.borrow().draw(&mut renderer);
             }
         },
-        move |evt: Event| {
+        move |evt: InputEvent| {
             root.borrow_mut().dispatch_event(&evt);
         },
     );

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -25,6 +25,16 @@ impl Label {
             text_color: Color(0, 0, 0),
         }
     }
+
+    /// Update the text displayed by the label.
+    pub fn set_text(&mut self, text: impl Into<String>) {
+        self.text = text.into();
+    }
+
+    /// Retrieve the current label text.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
 }
 
 impl Widget for Label {

--- a/widgets/tests/event_fuzz.rs
+++ b/widgets/tests/event_fuzz.rs
@@ -35,7 +35,7 @@ fn make_button(x: i32, y: i32, counter: Rc<RefCell<usize>>) -> WidgetNode {
         },
     );
     let c = counter.clone();
-    button.set_on_click(move || {
+    button.set_on_click(move |_: &mut Button| {
         *c.borrow_mut() += 1;
     });
     WidgetNode {


### PR DESCRIPTION
## Summary
- show live click counts on the demo button
- forward simulator events into rlvgl using `InputEvent`
- expose text setters/getters for labels and buttons

## Testing
- `./scripts/pre-commit.sh`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_688ff19e81488333a6204b9183845d3b