### PR TITLE
feat: add plugin menu button

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -65,4 +65,4 @@ This document tracks the high-level work streams and tasks for rlvgl development
 ## 10 Simulator examples
 - [x] Update samples/sim (rlvds-sim) to run rlvds in a window using std and the "simulator" feature
 - [x] Demonstrate core / widget features in examples/sim (use placeholder assets) using hierarchy matching the upper package
-- [x] Demonstrate plugin features (use placeholder assets) using hierarchy matching the upper package
+- [x] Demonstrate plugin features (use placeholder assets) using hierarchy matching the upper package; add a `plugins` button to the demo to launch optional items and set all build options

--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -1,15 +1,12 @@
 //! Runs the rlvgl simulator with demonstrations of core widgets and plugin features.
 use rlvgl::platform::{InputEvent, PixelsDisplay};
-use rlvgl_sim::{PixelsRenderer, build_demo, build_plugin_demo};
-use std::{cell::RefCell, rc::Rc};
+use rlvgl_sim::{PixelsRenderer, build_demo};
 
 const WIDTH: usize = 320;
 const HEIGHT: usize = 240;
 
 fn main() {
-    let (mut root, _counter) = build_demo();
-    root.children.push(build_plugin_demo());
-    let root = Rc::new(RefCell::new(root));
+    let (root, _counter) = build_demo();
 
     PixelsDisplay::new(WIDTH, HEIGHT).run(
         {
@@ -19,8 +16,11 @@ fn main() {
                 root.borrow().draw(&mut renderer);
             }
         },
-        move |evt: InputEvent| {
-            root.borrow_mut().dispatch_event(&evt);
+        {
+            let root = root.clone();
+            move |evt: InputEvent| {
+                root.borrow_mut().dispatch_event(&evt);
+            }
         },
     );
 }

--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -1,12 +1,14 @@
 //! Runs the rlvgl simulator with demonstrations of core widgets and plugin features.
 use rlvgl::platform::{InputEvent, PixelsDisplay};
-use rlvgl_sim::{PixelsRenderer, build_demo};
+use rlvgl_sim::{PixelsRenderer, build_demo, flush_pending};
 
 const WIDTH: usize = 320;
 const HEIGHT: usize = 240;
 
 fn main() {
-    let (root, _counter) = build_demo();
+    let demo = build_demo();
+    let root = demo.root.clone();
+    let pending = demo.pending.clone();
 
     PixelsDisplay::new(WIDTH, HEIGHT).run(
         {
@@ -18,8 +20,10 @@ fn main() {
         },
         {
             let root = root.clone();
+            let pending = pending.clone();
             move |evt: InputEvent| {
                 root.borrow_mut().dispatch_event(&evt);
+                flush_pending(&root, &pending);
             }
         },
     );

--- a/examples/sim/tests/demo.rs
+++ b/examples/sim/tests/demo.rs
@@ -4,7 +4,7 @@ use rlvgl::core::{
     renderer::Renderer,
     widget::{Color, Rect},
 };
-use rlvgl_sim::{build_demo, build_plugin_demo};
+use rlvgl_sim::{Demo, build_demo, build_plugin_demo, flush_pending};
 
 struct CountRenderer(u32);
 
@@ -19,7 +19,7 @@ impl Renderer for CountRenderer {
 
 #[test]
 fn demo_draws_widgets() {
-    let (root, _counter) = build_demo();
+    let Demo { root, .. } = build_demo();
     let mut renderer = CountRenderer(0);
     root.borrow().draw(&mut renderer);
     assert!(renderer.0 > 0);
@@ -27,12 +27,17 @@ fn demo_draws_widgets() {
 
 #[test]
 fn button_click_increments_counter() {
-    let (root, counter) = build_demo();
+    let Demo {
+        root,
+        counter,
+        pending,
+    } = build_demo();
     assert_eq!(*counter.borrow(), 0);
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 20, y: 50 })
     );
+    flush_pending(&root, &pending);
     assert_eq!(*counter.borrow(), 1);
 }
 
@@ -46,14 +51,16 @@ fn plugin_demo_renders_qrcode() {
 
 #[test]
 fn plugins_button_adds_demo() {
-    let (root, _counter) = build_demo();
+    let Demo { root, pending, .. } = build_demo();
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 110, y: 50 })
     );
+    flush_pending(&root, &pending);
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 30, y: 90 })
     );
+    flush_pending(&root, &pending);
     assert!(root.borrow().children.len() > 3);
 }

--- a/examples/sim/tests/demo.rs
+++ b/examples/sim/tests/demo.rs
@@ -21,15 +21,18 @@ impl Renderer for CountRenderer {
 fn demo_draws_widgets() {
     let (root, _counter) = build_demo();
     let mut renderer = CountRenderer(0);
-    root.draw(&mut renderer);
+    root.borrow().draw(&mut renderer);
     assert!(renderer.0 > 0);
 }
 
 #[test]
 fn button_click_increments_counter() {
-    let (mut root, counter) = build_demo();
+    let (root, counter) = build_demo();
     assert_eq!(*counter.borrow(), 0);
-    assert!(root.dispatch_event(&Event::PointerUp { x: 20, y: 50 }));
+    assert!(
+        root.borrow_mut()
+            .dispatch_event(&Event::PointerUp { x: 20, y: 50 })
+    );
     assert_eq!(*counter.borrow(), 1);
 }
 
@@ -39,4 +42,18 @@ fn plugin_demo_renders_qrcode() {
     let mut renderer = CountRenderer(0);
     node.draw(&mut renderer);
     assert!(renderer.0 > 0);
+}
+
+#[test]
+fn plugins_button_adds_demo() {
+    let (root, _counter) = build_demo();
+    assert!(
+        root.borrow_mut()
+            .dispatch_event(&Event::PointerUp { x: 110, y: 50 })
+    );
+    assert!(
+        root.borrow_mut()
+            .dispatch_event(&Event::PointerUp { x: 30, y: 90 })
+    );
+    assert!(root.borrow().children.len() > 3);
 }


### PR DESCRIPTION
## Summary
- add a `Plugins` button to simulator demo that shows a QR code example
- allow demo menu to display optional plugin features
- document plugin menu in TODO

## Testing
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ffd0cbf5083339462f2489f76abd6