### PR TITLE
Use fontdue for simulator text rendering

### DIFF
--- a/examples/sim/Cargo.toml
+++ b/examples/sim/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 include = ["src/**", "assets/**", "tests/**"]
 
 [dependencies]
-rlvgl= { version = "0.1.4", path = "../..", features = ["simulator", "qrcode", "png"], default-features = false }
+rlvgl= { version = "0.1.4", path = "../..", features = ["simulator", "qrcode", "png", "fontdue"], default-features = false }
 embedded-graphics = "0.8"
 
+[features]
+default = ["fontdue"]
+fontdue = []


### PR DESCRIPTION
## Summary
- enable `fontdue` for the simulator example
- rasterize text with `fontdue` in the simulator renderer
- load demo logo directly from the repository root

## Testing
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68910f496e2c8333ae83c2771cf9bd55