### PR TITLE
Scale click regions with window size

### DIFF
--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -164,7 +164,12 @@ impl PixelsDisplay {
                     pixels
                         .resize_surface(w.min(max_dim), h.min(max_dim))
                         .expect("failed to resize surface");
+                    let old = surface_size;
                     surface_size = (w, h);
+                    pointer_pos = (
+                        (pointer_pos.0 as f64 * old.0 as f64 / surface_size.0 as f64) as i32,
+                        (pointer_pos.1 as f64 * old.1 as f64 / surface_size.1 as f64) as i32,
+                    );
                     window.request_redraw();
                 }
                 Event::WindowEvent {

--- a/widgets/src/button.rs
+++ b/widgets/src/button.rs
@@ -11,6 +11,8 @@ type ClickHandler = Box<dyn FnMut(&mut Button)>;
 
 /// Clickable button widget.
 pub struct Button {
+    /// Bounding rectangle defining the clickable area.
+    bounds: Rect,
     label: Label,
     on_click: Option<ClickHandler>,
 }
@@ -19,6 +21,7 @@ impl Button {
     /// Create a new button with the provided label text.
     pub fn new(text: impl Into<String>, bounds: Rect) -> Self {
         Self {
+            bounds,
             label: Label::new(text, bounds),
             on_click: None,
         }
@@ -51,14 +54,14 @@ impl Button {
 
     /// Check if the given coordinates are inside the button's bounds.
     fn inside_bounds(&self, x: i32, y: i32) -> bool {
-        let b = self.label.bounds();
+        let b = self.bounds;
         x >= b.x && x < b.x + b.width && y >= b.y && y < b.y + b.height
     }
 }
 
 impl Widget for Button {
     fn bounds(&self) -> Rect {
-        self.label.bounds()
+        self.bounds
     }
 
     fn draw(&self, renderer: &mut dyn Renderer) {


### PR DESCRIPTION
## Summary
- scale simulator pointer coordinates when window resizes
- track button bounds so the entire button area is clickable

## Testing
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893e84a9704833384d96caaeedc5f81