### PR TITLE
Align text baseline in simulator and add boundary tests

### DIFF
--- a/examples/sim/src/lib.rs
+++ b/examples/sim/src/lib.rs
@@ -22,7 +22,7 @@ use rlvgl::core::{
     widget::{Color, Rect, Widget},
 };
 #[cfg(feature = "fontdue")]
-use rlvgl::fontdue::{line_metrics, rasterize_glyph};
+use rlvgl::fontdue::rasterize_glyph;
 use rlvgl::widgets::{button::Button, container::Container, image::Image, label::Label};
 #[cfg(feature = "fontdue")]
 const FONT_DATA: &[u8] = include_bytes!("../../../lvgl/scripts/built_in_font/DejaVuSans.ttf");
@@ -326,11 +326,7 @@ impl<'a> Renderer for PixelsRenderer<'a> {
     fn draw_text(&mut self, position: (i32, i32), text: &str, color: Color) {
         #[cfg(feature = "fontdue")]
         {
-            let vm = match line_metrics(FONT_DATA, 16.0) {
-                Ok(m) => m,
-                Err(_) => return,
-            };
-            let baseline = position.1 + vm.descent.round() as i32;
+            let baseline = position.1;
             let mut x_cursor = position.0;
             for ch in text.chars() {
                 if let Ok((bitmap, metrics)) = rasterize_glyph(FONT_DATA, ch, 16.0) {

--- a/examples/sim/tests/text.rs
+++ b/examples/sim/tests/text.rs
@@ -1,0 +1,52 @@
+//! Tests for simulator text rendering baseline alignment and boundary clipping.
+
+use rlvgl::core::{renderer::Renderer, widget::Color};
+use rlvgl_sim::PixelsRenderer;
+
+#[test]
+fn descenders_extend_below_baseline() {
+    let width = 32;
+    let height = 32;
+    let baseline = 16;
+    for ch in ['g', 'q'] {
+        let mut buf = vec![0u8; width * height * 4];
+        {
+            let mut renderer = PixelsRenderer::new(&mut buf, width, height);
+            renderer.draw_text((0, baseline), &ch.to_string(), Color(0xff, 0xff, 0xff));
+        }
+        let mut found = false;
+        for y in (baseline as usize + 1)..height {
+            for x in 0..width {
+                if buf[(y * width + x) * 4 + 3] != 0 {
+                    found = true;
+                    break;
+                }
+            }
+            if found {
+                break;
+            }
+        }
+        assert!(found, "character {ch} should render below the baseline");
+    }
+}
+
+#[test]
+fn draw_text_clips_to_frame_bounds() {
+    let width = 20;
+    let height = 20;
+    let mut frame = vec![0u8; width * height * 4 + 16];
+    let (buf, sentinel) = frame.split_at_mut(width * height * 4);
+    let sentinel_before = sentinel.to_vec();
+    {
+        let mut renderer = PixelsRenderer::new(buf, width, height);
+        // Partially outside to the left and bottom
+        renderer.draw_text((-5, height as i32 - 1), "gq", Color(0xff, 0xff, 0xff));
+        // Completely outside the frame
+        renderer.draw_text(
+            (width as i32 + 100, height as i32 + 100),
+            "gq",
+            Color(0xff, 0xff, 0xff),
+        );
+    }
+    assert_eq!(sentinel, &sentinel_before[..], "sentinel bytes modified");
+}

--- a/ui/src/input.rs
+++ b/ui/src/input.rs
@@ -11,6 +11,7 @@ use rlvgl_core::{
 use rlvgl_widgets::label::Label;
 
 /// Single-line text input component.
+#[allow(clippy::type_complexity)]
 pub struct Input {
     inner: Label,
     on_change: Option<Box<dyn FnMut(&str)>>,


### PR DESCRIPTION
## Summary
- align simulator fontdue renderer to use bottom baseline so descenders render below
- add tests covering text descenders and clipping outside the frame
- silence clippy type-complexity lint for Input

## Testing
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68949f981df48333bd41b1bd1bc94645