### PR TITLE
Refactor callbacks and clean clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The C version of LVGL is included as a git submodule for reference and test vect
 - [platform](https://github.com/SoftOboros/rlvgl/blob/main/platform/platform/README.md)/ – Display/input traits and HAL adapters
 - [support](https://github.com/SoftOboros/rlvgl/blob/main/support/README.md)/ – Fonts, geometry, style, color utils
 - [lvgl](https://github.com/lvgl/lvgl/blob/master/README.md)/ – C submodule (reference only)
+- [rlvgl-sim](https://github.com/SoftOboros/rlvgl/tree/main/examples/sim)/ – Desktop simulator example
 ## Status
 
 As-built. See [TODO](https://github.com/SoftOboros/rlvgl/blob/main/docs/TODO.md) for component-by-component progress.

--- a/examples/sim/src/lib.rs
+++ b/examples/sim/src/lib.rs
@@ -326,18 +326,16 @@ impl<'a> Renderer for PixelsRenderer<'a> {
     fn draw_text(&mut self, position: (i32, i32), text: &str, color: Color) {
         #[cfg(feature = "fontdue")]
         {
-            let vm = match line_metrics(FONT_DATA, 16.0) {
-                Ok(m) => m,
-                Err(_) => return,
-            };
-            let baseline = position.1 + vm.descent.round() as i32;
+            let vm = line_metrics(FONT_DATA, 16.0).unwrap();
+            let baseline = position.1 - vm.descent.round() as i32;
             let mut x_cursor = position.0;
             for ch in text.chars() {
                 if let Ok((bitmap, metrics)) = rasterize_glyph(FONT_DATA, ch, 16.0) {
                     let w = metrics.width as i32;
                     let h = metrics.height as i32;
+                    let draw_y = baseline + metrics.ymin;
                     for y in 0..h {
-                        let py = baseline + metrics.ymin + y;
+                        let py = draw_y + y;
                         if py < 0 || (py as usize) >= self.height {
                             continue;
                         }

--- a/examples/sim/tests/text.rs
+++ b/examples/sim/tests/text.rs
@@ -1,0 +1,186 @@
+//! Tests verifying text rendering alignment and clipping.
+use rlvgl::fontdue::{line_metrics, rasterize_glyph};
+
+const FONT_DATA: &[u8] = include_bytes!("../../../lvgl/scripts/built_in_font/DejaVuSans.ttf");
+
+/// Convert a grayscale framebuffer into an ASCII art representation.
+fn dump_ascii_frame(buffer: &[u8], width: usize, height: usize) -> String {
+    let mut out = String::with_capacity((width + 1) * height);
+    for y in 0..height {
+        for x in 0..width {
+            let val = buffer[y * width + x];
+            let ch = match val {
+                0 => ' ',
+                1..=63 => '.',
+                64..=127 => ':',
+                128..=191 => '*',
+                192..=223 => '#',
+                _ => '@',
+            };
+            out.push(ch);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Render `text` into the provided grayscale framebuffer using a bottom-aligned baseline.
+fn render_text_to_framebuffer(
+    text: &str,
+    fb: &mut [u8],
+    width: usize,
+    height: usize,
+    size: f32,
+    bottom_y: i32,
+) {
+    let vm = line_metrics(FONT_DATA, size).unwrap();
+    let baseline_y = bottom_y - vm.descent.round() as i32;
+    let mut x_cursor = 0f32;
+    for ch in text.chars() {
+        if let Ok((bitmap, metrics)) = rasterize_glyph(FONT_DATA, ch, size) {
+            let draw_y = baseline_y + metrics.ymin;
+            for y in 0..metrics.height {
+                let py = draw_y + y as i32;
+                if py < 0 || py as usize >= height {
+                    continue;
+                }
+                for x in 0..metrics.width {
+                    let px = x_cursor as i32 + metrics.xmin + x as i32;
+                    if px < 0 || px as usize >= width {
+                        continue;
+                    }
+                    let alpha = bitmap[y * metrics.width + x];
+                    fb[py as usize * width + px as usize] = alpha;
+                }
+            }
+            x_cursor += metrics.advance_width;
+        }
+    }
+}
+
+/// Render `text` with its top row positioned at `top_y`.
+fn render_text_top_aligned_to_framebuffer(
+    text: &str,
+    fb: &mut [u8],
+    width: usize,
+    height: usize,
+    size: f32,
+    top_y: i32,
+) {
+    let mut x_cursor = 0f32;
+    for ch in text.chars() {
+        if let Ok((bitmap, metrics)) = rasterize_glyph(FONT_DATA, ch, size) {
+            let draw_y = top_y;
+            for y in 0..metrics.height {
+                let py = draw_y + y as i32;
+                if py < 0 || py as usize >= height {
+                    continue;
+                }
+                for x in 0..metrics.width {
+                    let px = x_cursor as i32 + metrics.xmin + x as i32;
+                    if px < 0 || px as usize >= width {
+                        continue;
+                    }
+                    let alpha = bitmap[y * metrics.width + x];
+                    fb[py as usize * width + px as usize] = alpha;
+                }
+            }
+            x_cursor += metrics.advance_width;
+        }
+    }
+}
+
+/// Optionally dump `ascii` to files for manual inspection.
+/// Set the `ASCII_OUT` environment variable to a directory to enable.
+fn maybe_write_ascii(name: &str, ascii: &str) {
+    if let Ok(dir) = std::env::var("ASCII_OUT") {
+        let path = std::path::Path::new(&dir).join(format!("{name}.txt"));
+        let _ = std::fs::write(path, ascii);
+    }
+}
+
+#[test]
+fn test_descenders_render_below_baseline() {
+    const W: usize = 320;
+    const H: usize = 240;
+    let mut fb = vec![0u8; W * H];
+    let bottom_y = 200i32;
+    const TEXT: &str = "bgpq";
+    render_text_to_framebuffer(TEXT, &mut fb, W, H, 16.0, bottom_y);
+    let ascii = dump_ascii_frame(&fb, W, H);
+    maybe_write_ascii("descenders", &ascii);
+
+    let vm = line_metrics(FONT_DATA, 16.0).unwrap();
+    let baseline = bottom_y - vm.descent.round() as i32;
+    let mut top_line = baseline;
+    let mut bottom_line = baseline;
+    for (y, line) in ascii.lines().enumerate() {
+        if line.chars().any(|c| c != ' ') {
+            let y = y as i32;
+            if y < top_line {
+                top_line = y;
+            }
+            if y > bottom_line {
+                bottom_line = y;
+            }
+        }
+    }
+
+    let observed_above = baseline - top_line;
+    let observed_below = bottom_line - baseline;
+
+    let mut expected_above = 0;
+    let mut expected_below = 0;
+    for ch in TEXT.chars() {
+        if let Ok((_, m)) = rasterize_glyph(FONT_DATA, ch, 16.0) {
+            expected_above = expected_above.max(-m.ymin);
+            expected_below = expected_below.max(m.height as i32 + m.ymin);
+        }
+    }
+
+    assert_eq!(observed_above, expected_above);
+    assert!((observed_below - expected_below).abs() <= 1);
+
+    let lines: Vec<&str> = ascii.lines().collect();
+    let baseline_line = lines[baseline as usize].as_bytes();
+    let below_line = lines[(baseline + 1) as usize].as_bytes();
+    let mut x_cursor = 0f32;
+    for ch in TEXT.chars() {
+        if let Ok((_, m)) = rasterize_glyph(FONT_DATA, ch, 16.0) {
+            let start = (x_cursor as i32 + m.xmin).max(0) as usize;
+            let end = start + m.width;
+            assert!(baseline_line[start..end].iter().any(|&b| b != b' '));
+            if ch != 'b' {
+                assert!(below_line[start..end].iter().any(|&b| b != b' '));
+            }
+            x_cursor += m.advance_width;
+        }
+    }
+}
+
+#[test]
+fn test_clipped_bottom_text_does_not_panic() {
+    const W: usize = 320;
+    const H: usize = 240;
+    let mut fb = vec![0u8; W * H];
+    let vm = line_metrics(FONT_DATA, 16.0).unwrap();
+    let bottom_y = H as i32 - 1 + vm.descent.round() as i32;
+    render_text_to_framebuffer("pqgy", &mut fb, W, H, 16.0, bottom_y);
+    let ascii = dump_ascii_frame(&fb, W, H);
+    assert!(ascii.lines().last().unwrap().chars().any(|c| c != ' '));
+}
+
+#[test]
+fn test_top_aligned_text_differs_from_baseline() {
+    const W: usize = 60;
+    const H: usize = 30;
+    let vm = line_metrics(FONT_DATA, 16.0).unwrap();
+    let top_y = 5;
+    let baseline = top_y + vm.ascent.round() as i32;
+    let bottom = baseline + vm.descent.round() as i32;
+    let mut baseline_buf = vec![0u8; W * H];
+    render_text_to_framebuffer("Hi", &mut baseline_buf, W, H, 16.0, bottom);
+    let mut top_buf = vec![0u8; W * H];
+    render_text_top_aligned_to_framebuffer("Hi", &mut top_buf, W, H, 16.0, top_y);
+    assert_ne!(baseline_buf, top_buf);
+}

--- a/platform/src/st7789.rs
+++ b/platform/src/st7789.rs
@@ -1,5 +1,4 @@
 //! Driver for the ST7789 LCD controller.
-#![cfg(feature = "st7789")]
 use crate::display::DisplayDriver;
 use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
 use display_interface_spi::SPIInterface;
@@ -38,15 +37,15 @@ where
             0x2A,
             (area.x >> 8) as u8,
             area.x as u8,
-            ((area.x + area.width as i32 - 1) >> 8) as u8,
-            (area.x + area.width as i32 - 1) as u8,
+            ((area.x + area.width - 1) >> 8) as u8,
+            (area.x + area.width - 1) as u8,
         ]))?;
         self.interface.send_commands(DataFormat::U8(&[
             0x2B,
             (area.y >> 8) as u8,
             area.y as u8,
-            ((area.y + area.height as i32 - 1) >> 8) as u8,
-            (area.y + area.height as i32 - 1) as u8,
+            ((area.y + area.height - 1) >> 8) as u8,
+            (area.y + area.height - 1) as u8,
         ]))?;
         self.interface.send_commands(DataFormat::U8(&[0x2C]))
     }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 description = "High-level UI components and theming for rlvgl."
 
 [dependencies]
-rlvgl-core = { path = "../core", version = "0.1.4" }
-rlvgl-widgets = { path = "../widgets", version = "0.1.3" }
+rlvgl-core = { path = "../core", version = "0.1.4", default-features = false }
+rlvgl-widgets = { path = "../widgets", version = "0.1.3", default-features = false }
 
 [features]
 view = []

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -14,3 +14,4 @@ rlvgl-widgets = { path = "../widgets", version = "0.1.3", default-features = fal
 
 [features]
 view = []
+default = []

--- a/ui/src/checkbox.rs
+++ b/ui/src/checkbox.rs
@@ -67,10 +67,11 @@ impl Widget for Checkbox {
         let before = self.inner.is_checked();
         let handled = self.inner.handle_event(event);
         let after = self.inner.is_checked();
-        if handled && before != after {
-            if let Some(cb) = self.on_change.as_mut() {
-                cb(after);
-            }
+        if !handled || before == after {
+            return handled;
+        }
+        if let Some(cb) = self.on_change.as_mut() {
+            cb(after);
         }
         handled
     }

--- a/ui/src/event.rs
+++ b/ui/src/event.rs
@@ -80,10 +80,11 @@ impl Widget for Slider {
         let before = self.inner.value();
         let handled = self.inner.handle_event(event);
         let after = self.inner.value();
-        if handled && after != before {
-            if let Some(cb) = self.on_change.as_mut() {
-                cb(after);
-            }
+        if !handled || after == before {
+            return handled;
+        }
+        if let Some(cb) = self.on_change.as_mut() {
+            cb(after);
         }
         handled
     }

--- a/ui/src/icon.rs
+++ b/ui/src/icon.rs
@@ -4,7 +4,8 @@
 //! Maps human-readable icon names to LVGL built-in symbol codepoints and
 //! provides a fluent `icon` method on buttons.
 
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
+use core::fmt::Write;
 use rlvgl_widgets::button::Button;
 
 /// Resolve a human-friendly icon name to an LVGL symbol string.
@@ -27,7 +28,10 @@ impl Icon for Button {
     fn icon(mut self, name: &str) -> Self {
         if let Some(sym) = lookup(name) {
             let text = self.text().to_string();
-            self.set_text(format!("{sym} {text}"));
+            let mut buf = String::new();
+            // Write formatted text into the buffer; writing to a String cannot fail.
+            let _ = write!(&mut buf, "{sym} {text}");
+            self.set_text(&buf);
         }
         self
     }

--- a/ui/src/input.rs
+++ b/ui/src/input.rs
@@ -3,6 +3,7 @@
 //!
 //! These wrappers provide simple text fields backed by the base label widget.
 
+use alloc::boxed::Box;
 use rlvgl_core::{
     event::Event,
     renderer::Renderer,
@@ -10,10 +11,13 @@ use rlvgl_core::{
 };
 use rlvgl_widgets::label::Label;
 
+/// Callback type invoked when an input's text changes.
+type ChangeCallback = Box<dyn FnMut(&str)>;
+
 /// Single-line text input component.
 pub struct Input {
     inner: Label,
-    on_change: Option<Box<dyn FnMut(&str)>>,
+    on_change: Option<ChangeCallback>,
 }
 
 impl Input {

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 //! High-level style and theme utilities for rlvgl UI components.
 
+#![no_std]
+
 extern crate alloc;
 
 pub mod alert;

--- a/ui/src/radio.rs
+++ b/ui/src/radio.rs
@@ -67,10 +67,11 @@ impl Widget for Radio {
         let before = self.inner.is_selected();
         let handled = self.inner.handle_event(event);
         let after = self.inner.is_selected();
-        if handled && before != after {
-            if let Some(cb) = self.on_change.as_mut() {
-                cb(after);
-            }
+        if !handled || before == after {
+            return handled;
+        }
+        if let Some(cb) = self.on_change.as_mut() {
+            cb(after);
         }
         handled
     }

--- a/ui/src/switch.rs
+++ b/ui/src/switch.rs
@@ -67,10 +67,11 @@ impl Widget for Switch {
         let before = self.inner.is_on();
         let handled = self.inner.handle_event(event);
         let after = self.inner.is_on();
-        if handled && before != after {
-            if let Some(cb) = self.on_change.as_mut() {
-                cb(after);
-            }
+        if !handled || before == after {
+            return handled;
+        }
+        if let Some(cb) = self.on_change.as_mut() {
+            cb(after);
         }
         handled
     }


### PR DESCRIPTION
## Summary
- use callback type alias to simplify input components
- remove redundant attribute and casts in ST7789 driver
- mention rlvgl-sim in top-level documentation
- flatten checkbox, slider, radio, and switch event handlers to satisfy clippy
- align simulator text drawing with the font baseline and add regression tests
- add ASCII framebuffer utility and baseline alignment tests for descenders and clipping
- refine baseline test to compute ascender/descender extremes and optional ASCII dumps
- mark UI crate as `no_std` and replace `format!`/`Box` uses with `alloc` equivalents
- Fix fontdue baseline rendering in demo.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test -p rlvgl-sim`
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68948f9db8148333a5489b8b7e74f620