### PR TITLE
feat: improve simulator panic window

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -20,11 +20,11 @@ display-interface = { version = "0.5", optional = true }
 display-interface-spi = { version = "0.5", optional = true }
 pixels = { version = "0.15", optional = true }
 winit = { version = "0.30.12", optional = true }
-rfd = { version = "0.15.4", optional = true }
+eframe = { version = "0.27", default-features = false, features = ["glow"], optional = true }
 embedded-graphics = { version = "0.8", optional = true }
 
 [features]
 default = []
-simulator = ["pixels", "winit", "rfd", "embedded-graphics"]
+simulator = ["pixels", "winit", "embedded-graphics", "eframe"]
 st7789 = ["embedded-hal", "display-interface", "display-interface-spi"]
 fontdue = ["rlvgl-core/fontdue"]


### PR DESCRIPTION
## Summary
- replace message box panic handling with a scrollable `eframe` window
- cap panic window to monitor size and add copy/close controls
- wire up simulator feature to include `eframe`

## Testing
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68974c493c408333ba173fb4e346c614