### PR TITLE
fix: harden simulator widget toggling

### DIFF
--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -9,6 +9,7 @@ fn main() {
     let demo = build_demo();
     let root = demo.root.clone();
     let pending = demo.pending.clone();
+    let to_remove = demo.to_remove.clone();
 
     PixelsDisplay::new(WIDTH, HEIGHT).run(
         {
@@ -21,9 +22,10 @@ fn main() {
         {
             let root = root.clone();
             let pending = pending.clone();
+            let to_remove = to_remove.clone();
             move |evt: InputEvent| {
                 root.borrow_mut().dispatch_event(&evt);
-                flush_pending(&root, &pending);
+                flush_pending(&root, &pending, &to_remove);
             }
         },
     );

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -20,11 +20,11 @@ display-interface = { version = "0.5", optional = true }
 display-interface-spi = { version = "0.5", optional = true }
 pixels = { version = "0.15", optional = true }
 winit = { version = "0.30.12", optional = true }
-rfd = { version = "0.15.4", optional = true }
+eframe = { version = "0.27", default-features = false, features = ["glow"], optional = true }
 embedded-graphics = { version = "0.8", optional = true }
 
 [features]
 default = []
-simulator = ["pixels", "winit", "rfd", "embedded-graphics"]
+simulator = ["pixels", "winit", "embedded-graphics", "eframe"]
 st7789 = ["embedded-hal", "display-interface", "display-interface-spi"]
 fontdue = ["rlvgl-core/fontdue"]

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -3,13 +3,13 @@
 //! The window can be resized by the user and will scale the simulated
 //! display while preserving the aspect ratio of the configured dimensions.
 #[cfg(feature = "simulator")]
-use alloc::{boxed::Box, format, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec::Vec};
+#[cfg(feature = "simulator")]
+use eframe::{self, egui};
 #[cfg(feature = "simulator")]
 use pixels::{Pixels, SurfaceTexture};
 #[cfg(feature = "simulator")]
-use rfd::{MessageButtons, MessageDialog};
-#[cfg(feature = "simulator")]
-use std::{backtrace::Backtrace, panic};
+use std::{backtrace::Backtrace, eprintln, panic};
 #[cfg(feature = "simulator")]
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
@@ -60,6 +60,57 @@ fn generate_tiles_from_window(window: &Window, max_tile_size: u32) -> Vec<Tile> 
 }
 
 #[cfg(feature = "simulator")]
+/// Display a panic message in a scrollable window limited to the screen size.
+fn show_panic_window(message: String) {
+    /// Simple `eframe` application rendering the panic text.
+    struct PanicApp {
+        msg: String,
+    }
+
+    impl eframe::App for PanicApp {
+        fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                ui.heading("rlvgl panic");
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    ui.add(egui::TextEdit::multiline(&mut self.msg).desired_width(f32::INFINITY));
+                });
+                ui.horizontal(|ui| {
+                    if ui.button("Copy").clicked() {
+                        ctx.output_mut(|o| o.copied_text = self.msg.clone());
+                    }
+                    if ui.button("Close").clicked() {
+                        ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                });
+            });
+        }
+    }
+
+    let max = egui::vec2(800.0, 600.0);
+    let initial = egui::vec2(max.x * 0.8, max.y * 0.8);
+
+    let viewport = egui::ViewportBuilder::default()
+        .with_inner_size(initial)
+        .with_max_inner_size(max)
+        .with_decorations(true)
+        .with_resizable(true);
+
+    let options = eframe::NativeOptions {
+        viewport,
+        ..Default::default()
+    };
+
+    let msg_copy = message.clone();
+    if let Err(e) = eframe::run_native(
+        "rlvgl panic",
+        options,
+        Box::new(|_| Box::new(PanicApp { msg: message })),
+    ) {
+        eprintln!("{msg_copy}\nfailed to show panic window: {e}");
+    }
+}
+
+#[cfg(feature = "simulator")]
 /// Desktop simulator display backed by the `pixels` crate.
 pub struct PixelsDisplay {
     width: usize,
@@ -73,18 +124,16 @@ pub struct PixelsDisplay {
 impl PixelsDisplay {
     /// Create a new window with the given size.
     ///
-    /// Any panic during simulator execution triggers a message dialog
-    /// displaying the panic and a captured call stack. Selecting **OK** in
-    /// the dialog terminates the process.
+    /// Any panic during simulator execution opens a resizable window
+    /// displaying the panic and a captured call stack. The window is
+    /// constrained to the visible screen, provides a scrollbar for long
+    /// messages, and offers copy and close controls. Closing the window
+    /// terminates the process.
     pub fn new(width: usize, height: usize) -> Self {
         panic::set_hook(Box::new(|info| {
             let backtrace = Backtrace::force_capture();
             let message = format!("{info}\n\n{backtrace}");
-            let _ = MessageDialog::new()
-                .set_title("rlvgl panic")
-                .set_description(&message)
-                .set_buttons(MessageButtons::Ok)
-                .show();
+            show_panic_window(message);
             std::process::exit(1);
         }));
         let event_loop = EventLoop::new().expect("failed to create event loop");
@@ -131,8 +180,9 @@ impl PixelsDisplay {
 
         let mut pointer_pos = (0i32, 0i32);
         let mut pointer_down = false;
-        let mut surface_size = (width as u32, height as u32);
-        let mut surface_offset = (0i32, 0i32);
+        let mut surface_offset = (0.0f64, 0.0f64);
+        // Ratio between window pixels and logical display coordinates
+        let mut scale = (1.0f64, 1.0f64);
         let aspect_ratio = width as f64 / height as f64;
         let max_dim = pixels.device().limits().max_texture_dimension_2d;
         let mut _tiles = generate_tiles_from_window(window, max_dim);
@@ -166,18 +216,18 @@ impl PixelsDisplay {
                         }
                     }
                     surface_offset = (
-                        ((size.width as i32 - w as i32) / 2),
-                        ((size.height as i32 - h as i32) / 2),
+                        (size.width as f64 - w as f64) / 2.0,
+                        (size.height as f64 - h as f64) / 2.0,
                     );
                     _tiles = generate_tiles_from_window(window, max_dim);
                     pixels
                         .resize_surface(w.min(max_dim), h.min(max_dim))
                         .expect("failed to resize surface");
-                    let old = surface_size;
-                    surface_size = (w, h);
+                    let old_scale = scale;
+                    scale = (w as f64 / width as f64, h as f64 / height as f64);
                     pointer_pos = (
-                        (pointer_pos.0 as f64 * old.0 as f64 / surface_size.0 as f64) as i32,
-                        (pointer_pos.1 as f64 * old.1 as f64 / surface_size.1 as f64) as i32,
+                        (pointer_pos.0 as f64 * old_scale.0 / scale.0) as i32,
+                        (pointer_pos.1 as f64 * old_scale.1 / scale.1) as i32,
                     );
                     window.request_redraw();
                 }
@@ -205,13 +255,11 @@ impl PixelsDisplay {
                     event: WindowEvent::CursorMoved { position, .. },
                     ..
                 } => {
-                    let adj_x = position.x - surface_offset.0 as f64;
-                    let adj_y = position.y - surface_offset.1 as f64;
+                    let adj_x = position.x - surface_offset.0;
+                    let adj_y = position.y - surface_offset.1;
                     pointer_pos = (
-                        (adj_x * width as f64 / surface_size.0 as f64)
-                            .clamp(0.0, width as f64 - 1.0) as i32,
-                        (adj_y * height as f64 / surface_size.1 as f64)
-                            .clamp(0.0, height as f64 - 1.0) as i32,
+                        (adj_x / scale.0).clamp(0.0, width as f64 - 1.0) as i32,
+                        (adj_y / scale.1).clamp(0.0, height as f64 - 1.0) as i32,
                     );
                     if pointer_down {
                         event_callback(InputEvent::PointerMove {


### PR DESCRIPTION
## Summary
- defer widget removals to avoid RefCell panics when toggling demo plugins
- move QR code plugin to the right side of the screen and test its visibility
- fall back to logging if the simulator panic window cannot be displayed

## Testing
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68974c493c408333ba173fb4e346c614