### PR TITLE
Add alpha channel to Color and document rendering roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fn main() {
             height: 20,
         },
     );
-    label.style.bg_color = rlvgl_core::widget::Color(0, 0, 255);
+    label.style.bg_color = rlvgl_core::widget::Color(0, 0, 255, 255);
     // Rendering would use a DisplayDriver implementation.
 }
 ```

--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -41,6 +41,7 @@ impl Fade {
                 lerp(self.start.0, self.end.0) as u8,
                 lerp(self.start.1, self.end.1) as u8,
                 lerp(self.start.2, self.end.2) as u8,
+                lerp(self.start.3, self.end.3) as u8,
             );
         }
     }

--- a/core/src/plugins/apng.rs
+++ b/core/src/plugins/apng.rs
@@ -26,7 +26,7 @@ pub fn decode(data: &[u8]) -> Result<(Vec<ApngFrame>, u32, u32), ImageError> {
         let buffer = frame.into_buffer();
         let mut pixels = Vec::with_capacity((width * height) as usize);
         for chunk in buffer.into_raw().chunks_exact(4) {
-            pixels.push(Color(chunk[0], chunk[1], chunk[2]));
+            pixels.push(Color(chunk[0], chunk[1], chunk[2], 255));
         }
         frames_out.push(ApngFrame {
             pixels,
@@ -69,7 +69,7 @@ mod tests {
         let (frames, w, h) = decode(&data).unwrap();
         assert_eq!((w, h), (1, 1));
         assert_eq!(frames.len(), 2);
-        assert_eq!(frames[0].pixels[0], Color(255, 0, 0));
-        assert_eq!(frames[1].pixels[0], Color(0, 255, 0));
+        assert_eq!(frames[0].pixels[0], Color(255, 0, 0, 255));
+        assert_eq!(frames[1].pixels[0], Color(0, 255, 0, 255));
     }
 }

--- a/core/src/plugins/canvas.rs
+++ b/core/src/plugins/canvas.rs
@@ -32,8 +32,8 @@ impl Canvas {
             .pixels
             .iter()
             .map(|p| match p {
-                Some(c) => Color(c.r(), c.g(), c.b()),
-                None => Color(0, 0, 0),
+                Some(c) => Color(c.r(), c.g(), c.b(), 255),
+                None => Color(0, 0, 0, 255),
             })
             .collect()
     }
@@ -66,24 +66,24 @@ mod tests {
     #[test]
     fn draw_and_get_pixels() {
         let mut canvas = Canvas::new(1, 1);
-        canvas.draw_pixel(Point::new(0, 0), Color(255, 0, 0));
-        assert_eq!(canvas.pixels(), vec![Color(255, 0, 0)]);
+        canvas.draw_pixel(Point::new(0, 0), Color(255, 0, 0, 255));
+        assert_eq!(canvas.pixels(), vec![Color(255, 0, 0, 255)]);
     }
 
     #[test]
     fn blank_canvas_pixels() {
         let canvas = Canvas::new(1, 1);
-        assert_eq!(canvas.pixels(), vec![Color(0, 0, 0)]);
+        assert_eq!(canvas.pixels(), vec![Color(0, 0, 0, 255)]);
     }
 
     #[cfg(feature = "png")]
     #[test]
     fn export_png() {
         let mut canvas = Canvas::new(1, 1);
-        canvas.draw_pixel(Point::new(0, 0), Color(255, 0, 0));
+        canvas.draw_pixel(Point::new(0, 0), Color(255, 0, 0, 255));
         let data = canvas.to_png().unwrap();
         let (pixels, w, h) = crate::plugins::png::decode(&data).unwrap();
         assert_eq!((w, h), (1, 1));
-        assert_eq!(pixels, vec![Color(255, 0, 0)]);
+        assert_eq!(pixels, vec![Color(255, 0, 0, 255)]);
     }
 }

--- a/core/src/plugins/dash_lottie.rs
+++ b/core/src/plugins/dash_lottie.rs
@@ -55,7 +55,7 @@ pub fn load(data: &[u8]) -> Result<DashAnimation, &'static str> {
         }
         let mut pixels = Vec::with_capacity(width as usize * height as usize);
         for chunk in data[offset..offset + pixel_bytes].chunks_exact(3) {
-            pixels.push(Color(chunk[0], chunk[1], chunk[2]));
+            pixels.push(Color(chunk[0], chunk[1], chunk[2], 255));
         }
         offset += pixel_bytes;
         frames.push(DashFrame { pixels, delay });
@@ -100,15 +100,15 @@ mod tests {
         assert_eq!(anim.width, 1);
         assert_eq!(anim.height, 1);
         assert_eq!(anim.frames.len(), 2);
-        assert_eq!(anim.frames[0].pixels[0], Color(255, 0, 0));
-        assert_eq!(anim.frames[1].pixels[0], Color(0, 255, 0));
+        assert_eq!(anim.frames[0].pixels[0], Color(255, 0, 0, 255));
+        assert_eq!(anim.frames[1].pixels[0], Color(0, 255, 0, 255));
     }
 
     #[test]
     fn encode_roundtrip() {
         let anim = DashAnimation {
             frames: vec![DashFrame {
-                pixels: vec![Color(1, 2, 3)],
+                pixels: vec![Color(1, 2, 3, 255)],
                 delay: 10,
             }],
             width: 1,
@@ -116,7 +116,7 @@ mod tests {
         };
         let bytes = encode(&anim);
         let decoded = load(&bytes).unwrap();
-        assert_eq!(decoded.frames[0].pixels[0], Color(1, 2, 3));
+        assert_eq!(decoded.frames[0].pixels[0], Color(1, 2, 3, 255));
         assert_eq!(decoded.frames[0].delay, 10);
     }
 }

--- a/core/src/plugins/fontdue.rs
+++ b/core/src/plugins/fontdue.rs
@@ -160,7 +160,7 @@ mod tests {
             FONT_DATA,
             (0, 0),
             "A",
-            Color(255, 255, 255),
+            Color(255, 255, 255, 255),
             16.0,
         )
         .unwrap();

--- a/core/src/plugins/gif.rs
+++ b/core/src/plugins/gif.rs
@@ -30,7 +30,7 @@ pub fn decode(data: &[u8]) -> Result<(Vec<GifFrame>, u16, u16), DecodingError> {
 fn convert_frame(frame: &Frame<'_>, width: u16, height: u16) -> GifFrame {
     let mut pixels = Vec::with_capacity(width as usize * height as usize);
     for chunk in frame.buffer.chunks_exact(4) {
-        pixels.push(Color(chunk[0], chunk[1], chunk[2]));
+        pixels.push(Color(chunk[0], chunk[1], chunk[2], 255));
     }
     GifFrame {
         pixels,
@@ -53,6 +53,6 @@ mod tests {
         let (frames, w, h) = decode(&data).unwrap();
         assert_eq!((w, h), (1, 1));
         assert_eq!(frames.len(), 1);
-        assert_eq!(frames[0].pixels, vec![Color(255, 0, 0)]);
+        assert_eq!(frames[0].pixels, vec![Color(255, 0, 0, 255)]);
     }
 }

--- a/core/src/plugins/jpeg.rs
+++ b/core/src/plugins/jpeg.rs
@@ -15,19 +15,19 @@ pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u16, u16), Error> {
     match info.pixel_format {
         PixelFormat::L8 => {
             for &v in &pixels_raw {
-                pixels.push(Color(v, v, v));
+                pixels.push(Color(v, v, v, 255));
             }
         }
         PixelFormat::L16 => {
             for chunk in pixels_raw.chunks_exact(2) {
                 let val = u16::from_be_bytes([chunk[0], chunk[1]]);
                 let v = (val / 257) as u8;
-                pixels.push(Color(v, v, v));
+                pixels.push(Color(v, v, v, 255));
             }
         }
         PixelFormat::RGB24 => {
             for chunk in pixels_raw.chunks_exact(3) {
-                pixels.push(Color(chunk[0], chunk[1], chunk[2]));
+                pixels.push(Color(chunk[0], chunk[1], chunk[2], 255));
             }
         }
         PixelFormat::CMYK32 => {
@@ -39,7 +39,7 @@ pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u16, u16), Error> {
                 let r = (1.0 - (c * (1.0 - k) + k)) * 255.0;
                 let g = (1.0 - (m * (1.0 - k) + k)) * 255.0;
                 let b = (1.0 - (y * (1.0 - k) + k)) * 255.0;
-                pixels.push(Color(r as u8, g as u8, b as u8));
+                pixels.push(Color(r as u8, g as u8, b as u8, 255));
             }
         }
     }

--- a/core/src/plugins/lottie.rs
+++ b/core/src/plugins/lottie.rs
@@ -26,7 +26,7 @@ pub fn render_lottie_frame(
         surface
             .data()
             .iter()
-            .map(|px| Color(px.r, px.g, px.b))
+            .map(|px| Color(px.r, px.g, px.b, 255))
             .collect(),
     )
 }

--- a/core/src/plugins/png.rs
+++ b/core/src/plugins/png.rs
@@ -18,7 +18,7 @@ pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u32, u32), DecodingError> {
     match info.color_type {
         ColorType::Rgb => {
             for chunk in pixels_raw.chunks_exact(3) {
-                pixels.push(Color(chunk[0], chunk[1], chunk[2]));
+                pixels.push(Color(chunk[0], chunk[1], chunk[2], 255));
             }
         }
         ColorType::Rgba => {
@@ -27,12 +27,12 @@ pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u32, u32), DecodingError> {
                 let r = (chunk[0] as u32 * a + 127) / 255;
                 let g = (chunk[1] as u32 * a + 127) / 255;
                 let b = (chunk[2] as u32 * a + 127) / 255;
-                pixels.push(Color(r as u8, g as u8, b as u8));
+                pixels.push(Color(r as u8, g as u8, b as u8, 255));
             }
         }
         ColorType::Grayscale => {
             for &v in pixels_raw.iter() {
-                pixels.push(Color(v, v, v));
+                pixels.push(Color(v, v, v, 255));
             }
         }
         ColorType::GrayscaleAlpha => {
@@ -40,7 +40,7 @@ pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u32, u32), DecodingError> {
                 let v = chunk[0] as u32;
                 let a = chunk[1] as u32;
                 let c = (v * a + 127) / 255;
-                pixels.push(Color(c as u8, c as u8, c as u8));
+                pixels.push(Color(c as u8, c as u8, c as u8, 255));
             }
         }
         _ => {
@@ -65,7 +65,7 @@ mod tests {
             .unwrap();
         let (pixels, w, h) = decode(&data).unwrap();
         assert_eq!((w, h), (1, 1));
-        assert_eq!(pixels, vec![Color(255, 0, 0)]);
+        assert_eq!(pixels, vec![Color(255, 0, 0, 255)]);
     }
 
     #[test]
@@ -75,6 +75,6 @@ mod tests {
             .unwrap();
         let (pixels, w, h) = decode(&data).unwrap();
         assert_eq!((w, h), (1, 1));
-        assert_eq!(pixels, vec![Color(128, 0, 0)]);
+        assert_eq!(pixels, vec![Color(128, 0, 0, 255)]);
     }
 }

--- a/core/src/plugins/qrcode.rs
+++ b/core/src/plugins/qrcode.rs
@@ -14,8 +14,8 @@ pub fn generate(data: &[u8]) -> Result<(Vec<Color>, u32, u32), QrError> {
     let mut pixels = Vec::with_capacity((width * width) as usize);
     for m in modules {
         match m {
-            QrColor::Dark => pixels.push(Color(0, 0, 0)),
-            QrColor::Light => pixels.push(Color(255, 255, 255)),
+            QrColor::Dark => pixels.push(Color(0, 0, 0, 255)),
+            QrColor::Light => pixels.push(Color(255, 255, 255, 255)),
         }
     }
     Ok((pixels, width, width))
@@ -30,6 +30,6 @@ mod tests {
         let (pixels, w, h) = generate(b"hello").unwrap();
         assert_eq!(w, h);
         assert_eq!(pixels.len(), (w * h) as usize);
-        assert_eq!(pixels[0], Color(0, 0, 0));
+        assert_eq!(pixels[0], Color(0, 0, 0, 255));
     }
 }

--- a/core/src/style.rs
+++ b/core/src/style.rs
@@ -14,8 +14,8 @@ pub struct Style {
 impl Default for Style {
     fn default() -> Self {
         Self {
-            bg_color: crate::widget::Color(255, 255, 255),
-            border_color: crate::widget::Color(0, 0, 0),
+            bg_color: crate::widget::Color(255, 255, 255, 255),
+            border_color: crate::widget::Color(0, 0, 0, 255),
             border_width: 0,
         }
     }

--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -18,8 +18,8 @@ pub struct LightTheme;
 
 impl Theme for LightTheme {
     fn apply(&self, style: &mut Style) {
-        style.bg_color = Color(255, 255, 255);
-        style.border_color = Color(0, 0, 0);
+        style.bg_color = Color(255, 255, 255, 255);
+        style.border_color = Color(0, 0, 0, 255);
     }
 }
 
@@ -28,7 +28,7 @@ pub struct DarkTheme;
 
 impl Theme for DarkTheme {
     fn apply(&self, style: &mut Style) {
-        style.bg_color = Color(0, 0, 0);
-        style.border_color = Color(255, 255, 255);
+        style.bg_color = Color(0, 0, 0, 255);
+        style.border_color = Color(255, 255, 255, 255);
     }
 }

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -19,7 +19,7 @@ pub struct Rect {
     pub height: i32,
 }
 
-/// RGB color used by the renderer.
+/// RGBA color used by the renderer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color(
     /// Red component in the range `0..=255`.
@@ -27,6 +27,10 @@ pub struct Color(
     /// Green component in the range `0..=255`.
     pub u8,
     /// Blue component in the range `0..=255`.
+    pub u8,
+    /// Alpha component in the range `0..=255`.
+    ///
+    /// A value of `255` is fully opaque and `0` is fully transparent.
     pub u8,
 );
 

--- a/core/tests/animation.rs
+++ b/core/tests/animation.rs
@@ -6,17 +6,22 @@ use rlvgl_core::widget::{Color, Rect};
 #[test]
 fn fade_updates_bg_color() {
     let mut style = Style::default();
-    style.bg_color = Color(0, 0, 0);
+    style.bg_color = Color(0, 0, 0, 255);
     let start_color = style.bg_color;
     let mut timeline = Timeline::new();
-    timeline.add_fade(Fade::new(&mut style, start_color, Color(255, 0, 0), 100));
+    timeline.add_fade(Fade::new(
+        &mut style,
+        start_color,
+        Color(255, 0, 0, 255),
+        100,
+    ));
 
     timeline.tick(50);
-    assert_eq!(style.bg_color, Color(127, 0, 0));
+    assert_eq!(style.bg_color, Color(127, 0, 0, 255));
     assert!(!timeline.is_empty());
 
     timeline.tick(50);
-    assert_eq!(style.bg_color, Color(255, 0, 0));
+    assert_eq!(style.bg_color, Color(255, 0, 0, 255));
     assert!(timeline.is_empty());
 }
 

--- a/core/tests/style_builder.rs
+++ b/core/tests/style_builder.rs
@@ -5,8 +5,8 @@ use rlvgl_core::widget::Color;
 #[test]
 fn default_style() {
     let style = Style::default();
-    assert_eq!(style.bg_color, Color(255, 255, 255));
-    assert_eq!(style.border_color, Color(0, 0, 0));
+    assert_eq!(style.bg_color, Color(255, 255, 255, 255));
+    assert_eq!(style.border_color, Color(0, 0, 0, 255));
     assert_eq!(style.border_width, 0);
 }
 
@@ -19,11 +19,11 @@ fn builder_defaults_match() {
 #[test]
 fn builder_overrides() {
     let custom = StyleBuilder::new()
-        .bg_color(Color(10, 20, 30))
-        .border_color(Color(40, 50, 60))
+        .bg_color(Color(10, 20, 30, 255))
+        .border_color(Color(40, 50, 60, 255))
         .border_width(3)
         .build();
-    assert_eq!(custom.bg_color, Color(10, 20, 30));
-    assert_eq!(custom.border_color, Color(40, 50, 60));
+    assert_eq!(custom.bg_color, Color(10, 20, 30, 255));
+    assert_eq!(custom.border_color, Color(40, 50, 60, 255));
     assert_eq!(custom.border_width, 3);
 }

--- a/core/tests/theme.rs
+++ b/core/tests/theme.rs
@@ -8,25 +8,25 @@ use rlvgl_widgets::button::Button;
 #[test]
 fn light_theme_applies_defaults() {
     let mut style = Style::default();
-    style.bg_color = Color(10, 20, 30);
-    style.border_color = Color(5, 5, 5);
+    style.bg_color = Color(10, 20, 30, 255);
+    style.border_color = Color(5, 5, 5, 255);
 
     LightTheme.apply(&mut style);
 
-    assert_eq!(style.bg_color, Color(255, 255, 255));
-    assert_eq!(style.border_color, Color(0, 0, 0));
+    assert_eq!(style.bg_color, Color(255, 255, 255, 255));
+    assert_eq!(style.border_color, Color(0, 0, 0, 255));
 }
 
 #[test]
 fn dark_theme_applies_defaults() {
     let mut style = Style::default();
-    style.bg_color = Color(250, 250, 250);
-    style.border_color = Color(10, 10, 10);
+    style.bg_color = Color(250, 250, 250, 255);
+    style.border_color = Color(10, 10, 10, 255);
 
     DarkTheme.apply(&mut style);
 
-    assert_eq!(style.bg_color, Color(0, 0, 0));
-    assert_eq!(style.border_color, Color(255, 255, 255));
+    assert_eq!(style.bg_color, Color(0, 0, 0, 255));
+    assert_eq!(style.border_color, Color(255, 255, 255, 255));
 }
 
 #[test]
@@ -43,6 +43,6 @@ fn theme_updates_widget_style() {
 
     DarkTheme.apply(button.style_mut());
 
-    assert_eq!(button.style().bg_color, Color(0, 0, 0));
-    assert_eq!(button.style().border_color, Color(255, 255, 255));
+    assert_eq!(button.style().bg_color, Color(0, 0, 0, 255));
+    assert_eq!(button.style().border_color, Color(255, 255, 255, 255));
 }

--- a/docs/TODO-RENDERING.md
+++ b/docs/TODO-RENDERING.md
@@ -1,0 +1,13 @@
+# rlvgl – Rendering Workstream TODO
+
+This file tracks tasks for enhancing the rendering pipeline so widgets can draw multiple layers with alpha blending. All color values must carry RGBA data from source to display; if every layer is transparent at a pixel, the color from the lowest layer remains visible.
+
+## Alpha-enabled Rendering
+- [x] Extend `Color` from RGB to RGBA so widgets can express opacity.
+- [ ] Add alpha-aware blend methods to `Renderer` and update backends.
+- [ ] Define widget layering/compositing semantics so higher layers blend over lower ones.
+- [ ] Propagate RGBA colors through style and fill APIs across widgets and backends.
+
+---
+
+*Last updated 2025-08-06*

--- a/examples/sim/src/lib.rs
+++ b/examples/sim/src/lib.rs
@@ -240,7 +240,7 @@ pub fn build_plugin_demo() -> WidgetNode {
     let root_w = 320u32;
     let root_h = 240u32;
     // Match the area used by the PNG/JPEG demos: the lower-right 2/3rds of the display.
-    let target = (root_h * 2 / 3) as u32;
+    let target = root_h * 2 / 3;
     let scale = target as f32 / width as f32;
     let new_w = target;
     let new_h = target;
@@ -250,7 +250,10 @@ pub fn build_plugin_demo() -> WidgetNode {
             let src_x = (x as f32 / scale).floor() as usize;
             let src_y = (y as f32 / scale).floor() as usize;
             let idx = src_y * width as usize + src_x;
-            let color = pixels_vec.get(idx).copied().unwrap_or(Color(255, 255, 255));
+            let color = pixels_vec
+                .get(idx)
+                .copied()
+                .unwrap_or(Color(255, 255, 255, 255));
             scaled.push(color);
         }
     }
@@ -306,7 +309,7 @@ pub fn build_png_demo_scaled(scale: f32) -> WidgetNode {
             let src_x = (x as f32 / scale).floor() as usize;
             let src_y = (y as f32 / scale).floor() as usize;
             let idx = src_y * width as usize + src_x;
-            let color = pixels_vec.get(idx).copied().unwrap_or(Color(0, 0, 0));
+            let color = pixels_vec.get(idx).copied().unwrap_or(Color(0, 0, 0, 255));
             scaled.push(color);
         }
     }
@@ -368,7 +371,7 @@ pub fn build_jpeg_demo_scaled(scale: f32) -> WidgetNode {
             let src_x = (x as f32 / scale).floor() as usize;
             let src_y = (y as f32 / scale).floor() as usize;
             let idx = src_y * width as usize + src_x;
-            let color = pixels_vec.get(idx).copied().unwrap_or(Color(0, 0, 0));
+            let color = pixels_vec.get(idx).copied().unwrap_or(Color(0, 0, 0, 255));
             scaled.push(color);
         }
     }

--- a/examples/sim/tests/demo.rs
+++ b/examples/sim/tests/demo.rs
@@ -29,7 +29,7 @@ struct FramebufferRenderer {
 impl FramebufferRenderer {
     fn new(width: usize, height: usize) -> Self {
         Self {
-            buf: vec![Color(255, 255, 255); width * height],
+            buf: vec![Color(255, 255, 255, 255); width * height],
             width,
             height,
         }
@@ -198,7 +198,7 @@ fn qr_button_toggles_qrcode() {
     flush_pending(&root, &pending, &to_remove);
     let mut fb = FramebufferRenderer::new(320, 240);
     root.borrow().draw(&mut fb);
-    assert_ne!(fb.pixel(81, 1), Color(255, 255, 255));
+    assert_ne!(fb.pixel(81, 1), Color(255, 255, 255, 255));
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 30, y: 90 })
@@ -206,5 +206,5 @@ fn qr_button_toggles_qrcode() {
     flush_pending(&root, &pending, &to_remove);
     let mut fb = FramebufferRenderer::new(320, 240);
     root.borrow().draw(&mut fb);
-    assert_eq!(fb.pixel(81, 1), Color(255, 255, 255));
+    assert_eq!(fb.pixel(81, 1), Color(255, 255, 255, 255));
 }

--- a/platform/src/display.rs
+++ b/platform/src/display.rs
@@ -35,7 +35,7 @@ impl BufferDisplay {
         Self {
             width,
             height,
-            buffer: vec![Color(0, 0, 0); width * height],
+            buffer: vec![Color(0, 0, 0, 255); width * height],
         }
     }
 }

--- a/ui/src/style.rs
+++ b/ui/src/style.rs
@@ -90,9 +90,9 @@ pub struct Style {
 impl Default for Style {
     fn default() -> Self {
         Self {
-            bg_color: Color(255, 255, 255),
-            text_color: Color(0, 0, 0),
-            border_color: Color(0, 0, 0),
+            bg_color: Color(255, 255, 255, 255),
+            text_color: Color(0, 0, 0, 255),
+            border_color: Color(0, 0, 0, 255),
             border_width: 0,
             radius: 0,
             padding: 0,
@@ -170,18 +170,18 @@ mod tests {
     #[test]
     fn builder_sets_all_fields() {
         let style = StyleBuilder::new()
-            .bg(Color(1, 2, 3))
-            .text(Color(4, 5, 6))
-            .border_color(Color(7, 8, 9))
+            .bg(Color(1, 2, 3, 255))
+            .text(Color(4, 5, 6, 255))
+            .border_color(Color(7, 8, 9, 255))
             .border_width(2)
             .radius(3)
             .padding(4)
             .margin(5)
             .build();
 
-        assert_eq!(style.bg_color, Color(1, 2, 3));
-        assert_eq!(style.text_color, Color(4, 5, 6));
-        assert_eq!(style.border_color, Color(7, 8, 9));
+        assert_eq!(style.bg_color, Color(1, 2, 3, 255));
+        assert_eq!(style.text_color, Color(4, 5, 6, 255));
+        assert_eq!(style.border_color, Color(7, 8, 9, 255));
         assert_eq!(style.border_width, 2);
         assert_eq!(style.radius, 3);
         assert_eq!(style.padding, 4);

--- a/ui/src/theme.rs
+++ b/ui/src/theme.rs
@@ -71,9 +71,9 @@ pub struct Colors {
 impl Default for Colors {
     fn default() -> Self {
         Self {
-            primary: Color(98, 0, 238),
-            background: Color(255, 255, 255),
-            text: Color(0, 0, 0),
+            primary: Color(98, 0, 238, 255),
+            background: Color(255, 255, 255, 255),
+            text: Color(0, 0, 0, 255),
         }
     }
 }

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -25,8 +25,8 @@ impl Checkbox {
             bounds,
             text: text.into(),
             style: Style::default(),
-            text_color: Color(0, 0, 0),
-            check_color: Color(0, 0, 0),
+            text_color: Color(0, 0, 0, 255),
+            check_color: Color(0, 0, 0, 255),
             checked: false,
         }
     }

--- a/widgets/src/label.rs
+++ b/widgets/src/label.rs
@@ -22,7 +22,7 @@ impl Label {
             bounds,
             text: text.into(),
             style: Style::default(),
-            text_color: Color(0, 0, 0),
+            text_color: Color(0, 0, 0, 255),
         }
     }
 

--- a/widgets/src/list.rs
+++ b/widgets/src/list.rs
@@ -22,7 +22,7 @@ impl List {
         Self {
             bounds,
             style: Style::default(),
-            text_color: Color(0, 0, 0),
+            text_color: Color(0, 0, 0, 255),
             items: Vec::new(),
             selected: None,
         }

--- a/widgets/src/progress.rs
+++ b/widgets/src/progress.rs
@@ -22,7 +22,7 @@ impl ProgressBar {
         Self {
             bounds,
             style: Style::default(),
-            bar_color: Color(0, 0, 0),
+            bar_color: Color(0, 0, 0, 255),
             min,
             max,
             value: min,

--- a/widgets/src/radio.rs
+++ b/widgets/src/radio.rs
@@ -27,8 +27,8 @@ impl Radio {
             bounds,
             text: text.into(),
             style: Style::default(),
-            text_color: Color(0, 0, 0),
-            dot_color: Color(0, 0, 0),
+            text_color: Color(0, 0, 0, 255),
+            dot_color: Color(0, 0, 0, 255),
             selected: false,
         }
     }

--- a/widgets/src/slider.rs
+++ b/widgets/src/slider.rs
@@ -22,7 +22,7 @@ impl Slider {
         Self {
             bounds,
             style: Style::default(),
-            knob_color: Color(0, 0, 0),
+            knob_color: Color(0, 0, 0, 255),
             min,
             max,
             value: min,

--- a/widgets/src/switch.rs
+++ b/widgets/src/switch.rs
@@ -21,7 +21,7 @@ impl Switch {
         Self {
             bounds,
             style: Style::default(),
-            knob_color: Color(0, 0, 0),
+            knob_color: Color(0, 0, 0, 255),
             on: false,
         }
     }

--- a/widgets/tests/golden_button.rs
+++ b/widgets/tests/golden_button.rs
@@ -33,8 +33,8 @@ fn button_background_render() {
             height: 10,
         },
     );
-    button.style_mut().bg_color = Color(1, 2, 3);
+    button.style_mut().bg_color = Color(1, 2, 3, 255);
     button.draw(&mut renderer);
 
-    assert!(display.buffer.iter().all(|&c| c == Color(1, 2, 3)));
+    assert!(display.buffer.iter().all(|&c| c == Color(1, 2, 3, 255)));
 }

--- a/widgets/tests/golden_checkbox.rs
+++ b/widgets/tests/golden_checkbox.rs
@@ -33,16 +33,16 @@ fn checkbox_checked_render() {
             height: 12,
         },
     );
-    cb.style.bg_color = Color(1, 1, 1);
-    cb.style.border_color = Color(2, 2, 2);
-    cb.check_color = Color(3, 3, 3);
+    cb.style.bg_color = Color(1, 1, 1, 255);
+    cb.style.border_color = Color(2, 2, 2, 255);
+    cb.check_color = Color(3, 3, 3, 255);
     cb.set_checked(true);
     cb.draw(&mut renderer);
 
     // border pixel
-    assert_eq!(display.buffer[1 * 12 + 1], Color(2, 2, 2));
+    assert_eq!(display.buffer[1 * 12 + 1], Color(2, 2, 2, 255));
     // inner check pixel
-    assert_eq!(display.buffer[5 * 12 + 5], Color(3, 3, 3));
+    assert_eq!(display.buffer[5 * 12 + 5], Color(3, 3, 3, 255));
     // background pixel
-    assert_eq!(display.buffer[0 * 12 + 11], Color(1, 1, 1));
+    assert_eq!(display.buffer[0 * 12 + 11], Color(1, 1, 1, 255));
 }

--- a/widgets/tests/golden_container.rs
+++ b/widgets/tests/golden_container.rs
@@ -30,8 +30,8 @@ fn container_background_render() {
         width: 10,
         height: 10,
     });
-    container.style.bg_color = Color(1, 2, 3);
+    container.style.bg_color = Color(1, 2, 3, 255);
     container.draw(&mut renderer);
 
-    assert!(display.buffer.iter().all(|&c| c == Color(1, 2, 3)));
+    assert!(display.buffer.iter().all(|&c| c == Color(1, 2, 3, 255)));
 }

--- a/widgets/tests/golden_image.rs
+++ b/widgets/tests/golden_image.rs
@@ -25,10 +25,10 @@ fn image_render() {
     };
 
     let pixels = [
-        Color(1, 0, 0),
-        Color(0, 1, 0),
-        Color(0, 0, 1),
-        Color(1, 1, 1),
+        Color(1, 0, 0, 255),
+        Color(0, 1, 0, 255),
+        Color(0, 0, 1, 255),
+        Color(1, 1, 1, 255),
     ];
     let image = Image::new(
         Rect {

--- a/widgets/tests/golden_label.rs
+++ b/widgets/tests/golden_label.rs
@@ -32,8 +32,8 @@ fn label_background_render() {
             height: 10,
         },
     );
-    label.style.bg_color = Color(1, 2, 3);
+    label.style.bg_color = Color(1, 2, 3, 255);
     label.draw(&mut renderer);
 
-    assert!(display.buffer.iter().all(|&c| c == Color(1, 2, 3)));
+    assert!(display.buffer.iter().all(|&c| c == Color(1, 2, 3, 255)));
 }

--- a/widgets/tests/golden_list.rs
+++ b/widgets/tests/golden_list.rs
@@ -30,10 +30,10 @@ fn list_background_render() {
         width: 20,
         height: 32,
     });
-    list.style.bg_color = Color(1, 1, 1);
+    list.style.bg_color = Color(1, 1, 1, 255);
     list.add_item("a");
     list.add_item("b");
     list.draw(&mut renderer);
 
-    assert!(display.buffer.iter().all(|&c| c == Color(1, 1, 1)));
+    assert!(display.buffer.iter().all(|&c| c == Color(1, 1, 1, 255)));
 }

--- a/widgets/tests/golden_progress.rs
+++ b/widgets/tests/golden_progress.rs
@@ -34,13 +34,13 @@ fn progress_render() {
         0,
         10,
     );
-    bar.style.bg_color = Color(1, 1, 1);
-    bar.bar_color = Color(2, 2, 2);
+    bar.style.bg_color = Color(1, 1, 1, 255);
+    bar.bar_color = Color(2, 2, 2, 255);
     bar.set_value(5);
     bar.draw(&mut renderer);
 
     // pixel inside bar
-    assert_eq!(display.buffer[1 * 20 + 5], Color(2, 2, 2));
+    assert_eq!(display.buffer[1 * 20 + 5], Color(2, 2, 2, 255));
     // pixel outside bar
-    assert_eq!(display.buffer[1 * 20 + 15], Color(1, 1, 1));
+    assert_eq!(display.buffer[1 * 20 + 15], Color(1, 1, 1, 255));
 }

--- a/widgets/tests/golden_slider.rs
+++ b/widgets/tests/golden_slider.rs
@@ -34,17 +34,20 @@ fn slider_render() {
         0,
         10,
     );
-    slider.style.bg_color = Color(1, 1, 1);
-    slider.style.border_color = Color(2, 2, 2);
-    slider.knob_color = Color(3, 3, 3);
+    slider.style.bg_color = Color(1, 1, 1, 255);
+    slider.style.border_color = Color(2, 2, 2, 255);
+    slider.knob_color = Color(3, 3, 3, 255);
     slider.set_value(5);
     slider.draw(&mut renderer);
 
     // knob center pixel
-    assert_eq!(display.buffer[5 * 20 + 10], Color(3, 3, 3));
+    assert_eq!(display.buffer[5 * 20 + 10], Color(3, 3, 3, 255));
     // track pixel outside knob
     let track_y = 0 + (10 - 4) / 2 + 1; // middle of track
-    assert_eq!(display.buffer[track_y as usize * 20 + 2], Color(2, 2, 2));
+    assert_eq!(
+        display.buffer[track_y as usize * 20 + 2],
+        Color(2, 2, 2, 255)
+    );
     // background pixel above track
-    assert_eq!(display.buffer[0 * 20 + 0], Color(1, 1, 1));
+    assert_eq!(display.buffer[0 * 20 + 0], Color(1, 1, 1, 255));
 }


### PR DESCRIPTION
## Summary
- document rendering workstream and RGBA layering plan
- extend `Color` to RGBA and update usages across codebase

## Testing
- `cargo fmt --all`
- `cargo check`
- `./scripts/pre-commit.sh`
- `cargo test` *(fails: option `-C link-self-contained` unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6897cd1eb1e483338c148e2040f26917