### PR TITLE
Align PNG dependency versions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ publish = true
 
 [dependencies]
 
-png = { version = "0.18.0-rc.3", optional = true }
+png = { version = "0.17", optional = true }
 jpeg-decoder = { version = "0.3", optional = true }
 qrcode = { version = "0.14", default-features = false, optional = true }
 gif = { version = "0.13", optional = true }
@@ -48,7 +48,7 @@ rlvgl-widgets = { path = "../widgets" }
 doc-comment = "0.3"
 base64 = "0.22"
 apng = "0.3"
-png = "0.18.0-rc.3"
+png = "0.17"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/src/plugins/png.rs
+++ b/core/src/plugins/png.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 pub fn decode(data: &[u8]) -> Result<(Vec<Color>, u32, u32), DecodingError> {
     let decoder = Decoder::new(Cursor::new(data));
     let mut reader = decoder.read_info()?;
-    let mut buf = alloc::vec![0; reader.output_buffer_size().unwrap()];
+    let mut buf = alloc::vec![0; reader.output_buffer_size()];
     let info = reader.next_frame(&mut buf)?;
     let pixels_raw = &buf[..info.buffer_size()];
     let mut pixels = Vec::with_capacity(info.width as usize * info.height as usize);

--- a/examples/sim/tests/demo.rs
+++ b/examples/sim/tests/demo.rs
@@ -198,7 +198,7 @@ fn qr_button_toggles_qrcode() {
     flush_pending(&root, &pending, &to_remove);
     let mut fb = FramebufferRenderer::new(320, 240);
     root.borrow().draw(&mut fb);
-    assert_ne!(fb.pixel(81, 1), Color(255, 255, 255, 255));
+    assert!(fb.buf.iter().any(|&p| p != Color(255, 255, 255, 255)));
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 30, y: 90 })
@@ -206,5 +206,5 @@ fn qr_button_toggles_qrcode() {
     flush_pending(&root, &pending, &to_remove);
     let mut fb = FramebufferRenderer::new(320, 240);
     root.borrow().draw(&mut fb);
-    assert_eq!(fb.pixel(81, 1), Color(255, 255, 255, 255));
+    assert!(fb.buf.iter().all(|&p| p == Color(255, 255, 255, 255)));
 }


### PR DESCRIPTION
## Summary
- Match `png` crate version with `image` dependency
- Remove obsolete call to `output_buffer_size().unwrap()`
- Improve simulator QR-code test to scan framebuffer for changes

## Testing
- `cargo test --workspace --all-features`
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899ed37925883339e28a49bc1ea40c6