### PR TITLE
Make disco demo no_std-friendly by gating demo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ required-features = ["simulator", "qrcode", "png", "jpeg", "fontdue"]
 [[bin]]
 name = "rlvgl-stm32h747i-disco"
 path = "examples/stm32h747i-disco/src/main.rs"
-required-features = ["stm32h747i_disco", "qrcode", "png", "jpeg", "fontdue"]
+required-features = ["stm32h747i_disco"]
 doc = false
 
 [dependencies]
@@ -86,6 +86,10 @@ optional = true
 version = "0.2"
 optional = true
 
+[dependencies.embedded-alloc]
+version = "0.5"
+optional = true
+
 [features]
 default = []
 png = ["rlvgl-core/png"]
@@ -99,6 +103,7 @@ stm32h747i_disco = [
     "dep:cortex-m-rt",
     "dep:cortex-m",
     "dep:panic-halt",
+    "dep:embedded-alloc",
 ]
 fontdue = ["rlvgl-core/fontdue", "rlvgl-platform/fontdue", "dep:fontdue"]
 lottie = ["rlvgl-core/lottie", "dep:rlottie"]

--- a/examples/stm32h747i-disco/src/main.rs
+++ b/examples/stm32h747i-disco/src/main.rs
@@ -7,7 +7,11 @@
 //! constructs the shared widget demonstration. Real MIPI-DSI and touch
 //! handling will be added in future iterations.
 
+extern crate alloc;
+
+use core::ptr::addr_of_mut;
 use cortex_m_rt::entry;
+use embedded_alloc::Heap;
 use panic_halt as _;
 use rlvgl::platform::stm32h747i_disco::{Stm32h747iDiscoDisplay, Stm32h747iDiscoInput};
 
@@ -15,9 +19,24 @@ use rlvgl::platform::stm32h747i_disco::{Stm32h747iDiscoDisplay, Stm32h747iDiscoI
 mod common_demo;
 use common_demo::build_demo;
 
+/// Global allocator backed by a fixed-size heap in RAM.
+#[global_allocator]
+static ALLOC: Heap = Heap::empty();
+
+/// Heap size in bytes.
+const HEAP_SIZE: usize = 64 * 1024;
+
+/// Static memory region used to service heap allocations.
+static mut HEAP_MEM: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
+
 /// Application entry point.
 #[entry]
 fn main() -> ! {
+    unsafe {
+        let start = addr_of_mut!(HEAP_MEM) as usize;
+        ALLOC.init(start, HEAP_SIZE);
+    }
+
     let _display = Stm32h747iDiscoDisplay;
     let _touch = Stm32h747iDiscoInput;
     let _demo = build_demo();


### PR DESCRIPTION
## Summary
- gate optional PNG/JPEG/QR code demo helpers behind feature flags
- trim stm32h747i-disco binary to only require board support features
- provide a global allocator so the STM32H747I-DISCO example builds in no_std

## Testing
- `cargo check --bin rlvgl-sim --features "simulator,qrcode,png,jpeg,fontdue" --target x86_64-unknown-linux-gnu`
- `cargo check --bin rlvgl-stm32h747i-disco --features "stm32h747i_disco" --target thumbv7em-none-eabihf`
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_689abaf95a248333844121dd4a8d344e