### PR TITLE
Document example memory linker scripts and update disco build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,15 @@ documentation for users.
 All files must include a descriptive file header summarizing their purpose.
 
 Run ./scripts/pre-commit.sh and ensure it succeeds before opening a pull request. This script enforces formatting, runs clippy, builds with all features, and verifies documentation generation using nightly.
+
+## Example linker scripts
+
+Each example project that provides a `memory.x` linker script must include a
+`build.rs` which:
+
+- copies the local `memory.x` into the Cargo build output directory,
+- emits `cargo:rustc-link-search` for that directory, and
+- emits `cargo:rustc-link-arg=-Tmemory.x`.
+
+This avoids relying on a global `.cargo/config.toml` for linker script
+configuration.

--- a/examples/stm32h747i-disco/build.rs
+++ b/examples/stm32h747i-disco/build.rs
@@ -1,7 +1,8 @@
 //! Build script for the STM32H747I-DISCO example.
 //!
 //! Copies the `memory.x` linker script into the Cargo output directory so it
-//! can be located during the link step.
+//! can be located during the link step. It also instructs the linker to use
+//! that script explicitly.
 
 use std::{env, fs, path::PathBuf};
 
@@ -9,4 +10,5 @@ fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     fs::copy("memory.x", out_dir.join("memory.x")).expect("failed to copy memory.x");
     println!("cargo:rustc-link-search={}", out_dir.display());
+    println!("cargo:rustc-link-arg=-Tmemory.x");
 }


### PR DESCRIPTION
## Summary
- document that examples must use build scripts to copy and link their memory.x
- ensure stm32h747i-disco build script passes `-Tmemory.x` to the linker

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b5ae2275c8333be86d52336986370