### PR TITLE
feat(creator): add target presets and caching

### DIFF
--- a/.github/workflows/creator-e2e.yml
+++ b/.github/workflows/creator-e2e.yml
@@ -1,0 +1,30 @@
+# GitHub Actions workflow to exercise the rlvgl-creator pipeline end-to-end.
+# Ensures scan, convert, sync, scaffold, and vendor commands all succeed on
+# the example assets pack.
+name: creator-e2e
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  pipeline:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/iraa/rlvgl:latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare build environment
+        run: bash scripts/setup-ci-env.sh
+      - name: Build rlvgl-creator
+        run: cargo build --bin rlvgl-creator --features creator,lottie
+      - name: Run creator pipeline
+        run: |
+          target/debug/rlvgl-creator scan examples/assets-pack --manifest examples/assets-pack/manifest.yml
+          target/debug/rlvgl-creator convert examples/assets-pack --manifest examples/assets-pack/manifest.yml
+          target/debug/rlvgl-creator sync --out examples/assets-pack/out --manifest examples/assets-pack/manifest.yml
+          target/debug/rlvgl-creator scaffold examples/assets-pack/crate --manifest examples/assets-pack/manifest.yml
+          target/debug/rlvgl-creator vendor examples/assets-pack --out examples/assets-pack/out --allow MIT --manifest examples/assets-pack/manifest.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,14 @@ optional = true
 version = "0.11"
 optional = true
 
+[dependencies.rayon]
+version = "1"
+optional = true
+
+[dependencies.resvg]
+version = "0.45.1"
+optional = true
+
 [dev-dependencies]
 insta = "1"
 tempfile = "3"
@@ -158,6 +166,9 @@ creator = [
     "dep:serde_json",
     "dep:spdx",
     "dep:fontdue",
+    "dep:rlottie",
+    "dep:rayon",
+    "dep:resvg",
 ]
 
 [profile.release]

--- a/docs/CREATOR-TEMPLATES.md
+++ b/docs/CREATOR-TEMPLATES.md
@@ -1,0 +1,9 @@
+# rlvgl-creator Templates and Hooks
+
+Developer documentation describing how the creator uses embedded Tera templates for scaffolding assets crates and where to extend the conversion pipeline.
+
+## Templates
+The `scaffold` command builds an assets crate using Tera templates that are embedded as string constants in [`src/bin/creator/scaffold.rs`](../src/bin/creator/scaffold.rs). These templates cover files such as `Cargo.toml`, `lib.rs`, `build.rs`, and `README.md`. Modify the corresponding constants to change the generated crate layout or add new files.
+
+## Pipeline Hooks
+Conversion logic lives in modular Rust files like [`convert.rs`](../src/bin/creator/convert.rs), [`fonts.rs`](../src/bin/creator/fonts.rs), and [`lottie.rs`](../src/bin/creator/lottie.rs). New pipeline stages can hook into the process by adding a module and invoking it from `convert.rs`. Each step receives asset metadata and may emit outputs into `.cache` for reuse.

--- a/docs/TODO-CREATOR.md
+++ b/docs/TODO-CREATOR.md
@@ -24,7 +24,7 @@ _User story: As a maintainer, I want guardrails so teams can scale assets safely
 | [x] | Generate const/feature names; forbid manual edits (SCREAMING_SNAKE; `ICON_`, `FONT_`, `MEDIA_`). | creator core | Deterministic name map; diff output.
 | [x] | Creator is `std`; targets are `no_std + alloc` friendly; pre‑size/pack assets. | N/A | Design constraint across features.
 | [x] | Base assets stored as raw RGBA images/sequences; no PNG/APNG at runtime. | internal | Replaces std-dependent formats. |
-| [ ] | Support both direct Lottie playout and Lottie→APNG conversion. | rlottie (FFI) or Conan CLI | Per‑asset choice recorded in manifest.
+| [x] | Support both direct Lottie playout and Lottie→APNG conversion. | rlottie (FFI) or Conan CLI | Per‑asset choice recorded in manifest.
 | [x] | Optional bundle compression using RLE + token table; core path decodes with a tiny gated decoder. | internal | no_std-friendly; prefer build-time compress in vendor path. |
 
 ---
@@ -43,7 +43,7 @@ _User story: As a developer, I can manage assets via clear commands with helpful
 | [x] | `add-target` — register local crate + `vendor_dir` and presets. | serde_yaml | Updates manifest.
 | [x] | `sync` — regenerate Cargo features, consts, index from manifest. | tera | Dry‑run mode prints diff.
 | [x] | `apng` — build APNG from raw frame groups; set timing/loops. | apng | First frame PNG export. |
-| [ ] | `lottie import` — Lottie→frames/APNG; export timing map. | rlottie/CLI | Records chosen path.
+| [x] | `lottie import` — Lottie→frames/APNG; export timing map. | rlottie/CLI | Records chosen path.
 | [x] | `fonts pack` — sizes, glyph sets, packing/metrics. | fontdue/ab_glyph | Optional subsetting.
 | [x] | `check` — strict policy validation; `--fix` auto‑normalize. | creator core | Non‑zero exit on violations.
 | [ ] | `ui` — launch desktop UI. | Tauri or eframe/wgpu | Shares core libs.
@@ -62,8 +62,8 @@ _User story: As a maintainer, I want a machine‑owned manifest that encodes pol
 | [x] | Generate feature names from groups; emit `*_all` aggregates. | creator core | Stable order.
 | [x] | Generate const names from manifest entries; reject manual renames. | creator core | Diff prints old→new mapping.
 | [x] | License metadata per asset/group with allow/deny list. | SPDX table | Block vendor if missing.
-| [ ] | `naming` config (prefix map + case policy) for docs; generator is source of truth. | N/A | Keeps policy explicit.
-| [ ] | Per‑target presets (screen size, depth, storage) for auto sizing. | presets file | Hooked into `vendor`.
+| [x] | `naming` config (prefix map + case policy) for docs; generator is source of truth. | N/A | Keeps policy explicit.
+| [x] | Per‑target presets (screen size, depth, storage) for auto sizing. | presets file | Hooked into `vendor`.
 
 ---
 
@@ -90,10 +90,10 @@ _User story: As a designer, I can drop common formats and get normalized, fast�
 | [x] | Raw RGBA sequence format with max-frame header; per-frame size/position; single images drop frame headers. | internal | Replaces PNG/APNG base. |
 | [x] | Encode `.raw` files from common inputs. | creator core | Normalizes raster assets. |
 | [x] | Ingest `.raw` files into pipeline. | creator core | Parse header and frames. |
-| [ ] | SVG→sized raw images (DPI list; monochrome/e-ink thresholds). | resvg/usvg (opt.) | Fallback to external if needed. |
+| [x] | SVG→sized raw images (DPI list; monochrome/e-ink thresholds). | resvg/usvg (opt.) | Fallback to external if needed. |
 | [x] | APNG builder from raw frames with per-frame delay and loop count; first-frame PNG. | apng | Frame ordering checks. |
-| [ ] | Lottie via FFI (`lottie-ffi`) using `rlottie`. | rlottie, Conan | Feature gate; platform notes.
-| [ ] | Lottie via external CLI (`lottie-cli`) to frames/APNG. | Conan recipe | Record path in manifest.
+| [x] | Lottie via FFI (`lottie-ffi`) using `rlottie`. | rlottie, Conan | Feature gate; platform notes.
+| [x] | Lottie via external CLI (`lottie-cli`) to frames/APNG. | Conan recipe | Record path in manifest.
 | [x] | Fonts: TTF/OTF→bitmap packs (`.bin`) + metrics (`.json`); optional subset. | fontdue/ab_glyph | Glyph set per target.
 | [x] | Simple RLE + token table compression for raw files. | internal | Tiny decoder for no_std targets. |
 
@@ -136,9 +136,9 @@ _User story: As a user, I want fast re‑runs with deterministic outputs._
 
 | Complete | Description | Dependencies | Notes |
 |---|---|---|---|
-| [ ] | Content‑hash cache in `assets/.cache` (hash→outputs/timestamps/sizes). | blake3, serde | JSON/CBOR store.
-| [ ] | `--force` invalidation and smart rebuild by hash/mtime. | creator core | Clear messaging.
-| [ ] | Parallelize conversions with stable ordering. | rayon (opt.) | Guard race conditions.
+| [x] | Content‑hash cache in `assets/.cache` (hash→outputs/timestamps/sizes). | blake3, serde | JSON/CBOR store.
+| [x] | `--force` invalidation and smart rebuild by hash/mtime. | creator core | Clear messaging.
+| [x] | Parallelize conversions with stable ordering. | rayon (opt.) | Guard race conditions.
 | [x] | Emit `cargo:rerun-if-changed` hints for vendor/build steps. | build.rs API | Good DX for consumers.
 
 ---
@@ -148,10 +148,10 @@ _User story: As a maintainer, I can trust every PR to enforce policy and stay gr
 
 | Complete | Description | Dependencies | Notes |
 |---|---|---|---|
-| [ ] | `creator check` covers paths, names, license, duplicates, size thresholds. | creator core | Non‑zero exit.
+| [x] | `creator check` covers paths, names, license, duplicates, size thresholds. | creator core | Non‑zero exit.
 | [x] | Pre‑commit hook template (scan/convert/check). | git hooks | Optional but encouraged.
-| [ ] | CI job runs end‑to‑end: `scan → convert → sync → scaffold → vendor`. | GH Actions | Caches toolchains.
-| [ ] | Golden tests for APNG timing and font samples. | apng, fontdue | Deterministic fixtures.
+| [x] | CI job runs end‑to‑end: `scan → convert → sync → scaffold → vendor`. | GH Actions | Caches toolchains.
+| [x] | Golden tests for APNG timing and font samples. | apng, fontdue | Deterministic fixtures.
 | [x] | Snapshot tests for generated `Cargo.toml`, `lib.rs`, `rlvgl_assets.rs`. | insta | Stored in repo.
 
 ---
@@ -205,4 +205,4 @@ _User story: As a newcomer, I can get productive with clear examples and guides.
 | [x] | Example assets pack (icons/fonts/media) with manifest. | repo data | Used in tests.
 | [ ] | Two consumer examples: **embed** and **vendor** patterns. | examples | CI builds & runs.
 | [x] | User guide (README) with end‑to‑end workflow. | mdbook/README | Screenshots/gifs.
-| [ ] | Developer docs for templates (Tera) and pipeline hooks. | rustdoc | API + templates directory.
+| [x] | Developer docs for templates (Tera) and pipeline hooks. | rustdoc | API + templates directory.

--- a/examples/assets-pack/manifest.yml
+++ b/examples/assets-pack/manifest.yml
@@ -8,11 +8,20 @@ groups:
   media:
     assets:
       - media/blue.raw
+      - media/spinner.json
     license: MIT
   fonts:
     assets:
       - fonts/unscii-8.ttf
     license: MIT
+targets:
+  - name: default
+    vendor_dir: vendor
+    preset:
+      width: 480
+      height: 272
+      color_depth: 16
+      storage: qspi
 assets:
   - name: ICON_RED_RAW
     path: icons/red.raw
@@ -22,7 +31,18 @@ assets:
     path: media/blue.raw
     hash: 90a7b7ff3b01b6debd72150b718e37ace1a6f64f6832f54af7a82ef9da98c6db
     license: MIT
+  - name: MEDIA_SPINNER_JSON
+    path: media/spinner.json
+    hash: 0000000000000000000000000000000000000000000000000000000000000000
+    license: MIT
+    lottie: apng
   - name: FONT_UNSCII_8_TTF
     path: fonts/unscii-8.ttf
     hash: f5828de359175367373ae57f21ddd53c8ace5084cd7d1602bcc20146415decd8
     license: MIT
+naming:
+  prefixes:
+    icons: ICON_
+    media: MEDIA_
+    fonts: FONT_
+  case: screaming_snake

--- a/src/bin/creator/README.md
+++ b/src/bin/creator/README.md
@@ -20,7 +20,14 @@ A command-line tool for normalizing assets and generating dual-mode assets crate
    ```sh
    cargo run --bin rlvgl-creator --features creator,fontdue -- convert
    ```
-   Raster images become raw RGBA sequences, and fonts are packed into bitmap binaries and metrics.
+   Raster images become raw RGBA sequences, and fonts are packed into bitmap binaries and metrics. Conversions run in parallel
+   with stable ordering. Use `--force` to rebuild all assets regardless of cache.
+
+   To render vector assets, the `svg` command converts an SVG into one or more raw images at chosen DPI values:
+   ```sh
+   cargo run --bin rlvgl-creator --features creator -- svg logo.svg out/ --dpi 96 --dpi 192
+   ```
+   Supply `--threshold <VAL>` to apply a monochrome cutoff suitable for e-ink displays.
 
 4. **Synchronize feature flags, constants, and index**
    ```sh
@@ -41,3 +48,8 @@ A command-line tool for normalizing assets and generating dual-mode assets crate
    Copies processed assets to `$OUT_DIR` and emits an `rlvgl_assets.rs` module for inclusion.
 
 The resulting crate can be built with `--features embed` to include raw bytes or `--features vendor` to copy files at build time while importing the generated module.
+
+## Developer Notes
+
+For details on customizing scaffold templates and extending the conversion pipeline, see
+[`docs/CREATOR-TEMPLATES.md`](../../../docs/CREATOR-TEMPLATES.md).

--- a/src/bin/creator/add_target.rs
+++ b/src/bin/creator/add_target.rs
@@ -29,6 +29,7 @@ pub(crate) fn run(manifest_path: &Path, name: &str, vendor_dir: &Path) -> Result
             manifest.targets.push(Target {
                 name: name.to_string(),
                 vendor_dir: dir_str.clone(),
+                preset: None,
             });
             println!("Added target `{}`", name);
         }

--- a/src/bin/creator/check.rs
+++ b/src/bin/creator/check.rs
@@ -2,7 +2,7 @@
 //!
 //! Validates manifest entries against asset files and naming policies.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
@@ -13,6 +13,9 @@ use crate::manifest::Manifest;
 use crate::scan;
 use crate::util::{const_name, valid_root};
 use serde_yaml;
+
+/// Maximum allowed asset file size in bytes.
+const MAX_FILE_BYTES: u64 = 1_048_576;
 
 /// Verify manifest paths, hashes, and names, optionally fixing issues.
 pub(crate) fn run(root: &Path, manifest_path: &Path, fix: bool) -> Result<()> {
@@ -33,6 +36,15 @@ pub(crate) fn run(root: &Path, manifest_path: &Path, fix: bool) -> Result<()> {
     let mut seen_names = HashSet::new();
     let mut new_assets = Vec::new();
 
+    let mut group_license = HashMap::new();
+    for group in manifest.groups.values() {
+        if let Some(ref lic) = group.license {
+            for path in &group.assets {
+                group_license.insert(path.clone(), lic.clone());
+            }
+        }
+    }
+
     for mut asset in manifest.assets.into_iter() {
         if !seen_paths.insert(asset.path.clone()) {
             if fix {
@@ -49,6 +61,20 @@ pub(crate) fn run(root: &Path, manifest_path: &Path, fix: bool) -> Result<()> {
                 continue;
             }
             issues.push(format!("Duplicate name `{}`", asset.name));
+        }
+
+        if asset.license.is_none() {
+            if let Some(lic) = group_license.get(&asset.path) {
+                if fix {
+                    println!("Filled license for `{}`", asset.path);
+                    asset.license = Some(lic.clone());
+                    changed = true;
+                } else {
+                    issues.push(format!("Missing license for `{}`", asset.path));
+                }
+            } else {
+                issues.push(format!("Missing license for `{}`", asset.path));
+            }
         }
 
         let asset_path = root.join(&asset.path);
@@ -68,6 +94,20 @@ pub(crate) fn run(root: &Path, manifest_path: &Path, fix: bool) -> Result<()> {
                 continue;
             }
             issues.push(format!("Invalid root `{}`", asset.path));
+        }
+
+        let metadata = fs::metadata(&asset_path)?;
+        let size = metadata.len();
+        if size > MAX_FILE_BYTES {
+            if fix {
+                println!("Removed oversize file `{}`", asset.path);
+                changed = true;
+                continue;
+            }
+            issues.push(format!(
+                "File `{}` exceeds {} bytes ({} bytes)",
+                asset.path, MAX_FILE_BYTES, size
+            ));
         }
 
         let data = fs::read(&asset_path)?;

--- a/src/bin/creator/convert.rs
+++ b/src/bin/creator/convert.rs
@@ -1,17 +1,45 @@
 //! Convert command for rlvgl-creator.
 //!
-//! Normalizes raster assets to raw RGBA sequences and refreshes the manifest.
+//! Normalizes raster assets to raw RGBA sequences, caches conversions by
+//! content hash, and refreshes the manifest.
 
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
+use blake3::Hasher;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 use crate::{check, raw};
 
-/// Convert assets under the root to `.raw` and refresh the manifest.
-pub(crate) fn run(root: &Path, manifest_path: &Path) -> Result<()> {
+/// Work item describing a source asset pending conversion.
+struct Task {
+    rel: String,
+    path: PathBuf,
+    data: Vec<u8>,
+    src_mtime: u64,
+    hash: String,
+}
+
+/// Result of a conversion including cache metadata and log message.
+struct ConvResult {
+    rel: String,
+    entry: CacheEntry,
+    log: String,
+}
+
+/// Convert assets under the root to `.raw`, caching by content hash, and
+/// refresh the manifest.
+pub(crate) fn run(root: &Path, manifest_path: &Path, force: bool) -> Result<()> {
+    let cache_path = root.join(".cache/convert.json");
+    let mut cache = Cache::load(&cache_path)?;
+    let mut seen = HashSet::new();
+    let mut tasks = Vec::new();
+
     for entry in WalkDir::new(root)
         .follow_links(true)
         .into_iter()
@@ -38,15 +66,150 @@ pub(crate) fn run(root: &Path, manifest_path: &Path) -> Result<()> {
             continue;
         }
 
-        let img = image::open(path)?;
-        let dest = path.with_extension("raw");
-        raw::encode_image(img, &dest)?;
-        fs::remove_file(path)?;
-        println!("Converted {} -> {}", path.display(), dest.display());
+        let rel_str = rel.to_string_lossy().to_string();
+        seen.insert(rel_str.clone());
+
+        let src_meta = fs::metadata(path)?;
+        let src_mtime = src_meta
+            .modified()
+            .unwrap_or(SystemTime::UNIX_EPOCH)
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        if !force {
+            if let Some(entry) = cache.entries.get(&rel_str) {
+                let outputs_exist = entry.outputs.iter().all(|o| root.join(&o.path).exists());
+                let outputs_fresh = entry.outputs.iter().all(|o| o.mtime >= src_mtime);
+                if entry.src_mtime == src_mtime && outputs_exist && outputs_fresh {
+                    println!("Skipping {} (cached)", path.display());
+                    continue;
+                }
+            }
+        }
+
+        let data = fs::read(path)?;
+        let mut hasher = Hasher::new();
+        hasher.update(&data);
+        let hash = hasher.finalize().to_hex().to_string();
+
+        if !force {
+            if let Some(entry) = cache.entries.get_mut(&rel_str) {
+                let outputs_exist = entry.outputs.iter().all(|o| root.join(&o.path).exists());
+                if entry.hash == hash && outputs_exist {
+                    entry.src_mtime = src_mtime;
+                    for o in &mut entry.outputs {
+                        o.mtime = o.mtime.max(src_mtime);
+                    }
+                    println!("Skipping {} (unchanged)", path.display());
+                    continue;
+                }
+            }
+        }
+
+        tasks.push(Task {
+            rel: rel_str,
+            path: path.to_path_buf(),
+            data,
+            src_mtime,
+            hash,
+        });
     }
 
+    tasks.sort_by(|a, b| a.rel.cmp(&b.rel));
+
+    let results: Vec<ConvResult> = tasks
+        .into_par_iter()
+        .map(|t| -> Result<ConvResult> {
+            let img = image::load_from_memory(&t.data)?;
+            let dest = t.path.with_extension("raw");
+            raw::encode_image(img, &dest)?;
+            fs::remove_file(&t.path)?;
+
+            let meta = fs::metadata(&dest)?;
+            let mtime = meta
+                .modified()
+                .unwrap_or(SystemTime::UNIX_EPOCH)
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            Ok(ConvResult {
+                rel: t.rel,
+                log: format!("Converted {} -> {}", t.path.display(), dest.display()),
+                entry: CacheEntry {
+                    hash: t.hash,
+                    src_mtime: t.src_mtime,
+                    outputs: vec![CacheOutput {
+                        path: dest.strip_prefix(root)?.to_path_buf(),
+                        size: meta.len(),
+                        mtime,
+                    }],
+                },
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    for r in &results {
+        println!("{}", r.log);
+    }
+
+    for r in results {
+        cache.entries.insert(r.rel, r.entry);
+    }
+
+    cache.retain(&seen);
+    cache.save(&cache_path)?;
     check::run(root, manifest_path, true)?;
     Ok(())
+}
+
+/// Persistent cache of conversions keyed by source path.
+#[derive(Default, Serialize, Deserialize)]
+struct Cache {
+    entries: HashMap<String, CacheEntry>,
+}
+
+impl Cache {
+    /// Load the cache from disk if present.
+    fn load(path: &Path) -> Result<Self> {
+        if let Ok(data) = fs::read_to_string(path) {
+            Ok(serde_json::from_str(&data)?)
+        } else {
+            Ok(Self::default())
+        }
+    }
+
+    /// Write the cache to disk.
+    fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let data = serde_json::to_string_pretty(self)?;
+        fs::write(path, data)?;
+        Ok(())
+    }
+
+    /// Drop cache entries not seen during the current run.
+    fn retain(&mut self, seen: &HashSet<String>) {
+        self.entries.retain(|k, _| seen.contains(k));
+    }
+}
+
+/// Metadata for a single cached source file.
+#[derive(Serialize, Deserialize)]
+struct CacheEntry {
+    hash: String,
+    /// Source file modification time
+    src_mtime: u64,
+    outputs: Vec<CacheOutput>,
+}
+
+/// Output information for a converted file.
+#[derive(Serialize, Deserialize)]
+struct CacheOutput {
+    path: PathBuf,
+    size: u64,
+    mtime: u64,
 }
 
 #[cfg(test)]
@@ -75,7 +238,7 @@ mod tests {
 
         let manifest = tmp.path().join("manifest.yml");
         scan::run(tmp.path(), &manifest).unwrap();
-        super::run(tmp.path(), &manifest).unwrap();
+        super::run(tmp.path(), &manifest, false).unwrap();
 
         let data = fs::read_to_string(&manifest).unwrap();
         let manifest: crate::manifest::Manifest = serde_yaml::from_str(&data).unwrap();

--- a/src/bin/creator/lottie.rs
+++ b/src/bin/creator/lottie.rs
@@ -1,0 +1,101 @@
+//! Lottie import utilities for rlvgl-creator.
+//!
+//! Converts a Lottie JSON animation into a sequence of PNG frames and an
+//! optional animated PNG, exporting per-frame timing information as JSON.
+//! Supports both in-process rendering via the `rlottie` crate and invoking
+//! an external `lottie-cli` binary.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Result, anyhow};
+use image::{Rgba, RgbaImage};
+use rlottie::{Animation, Surface};
+
+use crate::apng;
+
+/// Import a Lottie animation from `json` into `out` directory.
+///
+/// Writes PNG frame files and a `timing.json` map. If `apng_out` is
+/// provided, an APNG is assembled from the generated frames.
+pub(crate) fn import(json: &Path, out: &Path, apng_out: Option<&Path>) -> Result<()> {
+    let data = fs::read_to_string(json)?;
+    let mut anim = Animation::from_data(data, json.to_string_lossy().as_ref(), ".")
+        .ok_or_else(|| anyhow!("invalid Lottie JSON"))?;
+    let size = anim.size();
+    fs::create_dir_all(out)?;
+    let mut surface = Surface::new(size);
+    let delay = (1000.0 / anim.framerate()) as u16;
+    let mut timings = Vec::new();
+
+    for frame in 0..anim.totalframe() {
+        anim.render(frame, &mut surface);
+        let mut img = RgbaImage::new(size.width as u32, size.height as u32);
+        for (x, y, px) in surface.pixels() {
+            img.put_pixel(x as u32, y as u32, Rgba([px.r, px.g, px.b, px.a]));
+        }
+        let frame_path = out.join(format!("frame_{:04}.png", frame));
+        img.save(&frame_path)?;
+        timings.push(delay);
+    }
+
+    fs::write(out.join("timing.json"), serde_json::to_vec(&timings)?)?;
+
+    if let Some(apng_path) = apng_out {
+        apng::run(out, apng_path, delay, 0)?;
+    }
+
+    println!(
+        "Imported {} frames from {} into {}",
+        timings.len(),
+        json.display(),
+        out.display()
+    );
+    Ok(())
+}
+
+/// Import a Lottie animation using an external CLI tool.
+///
+/// Invokes `cli` to render `json` into `out`, generates a constant-delay
+/// `timing.json`, and optionally assembles an APNG from the frames.
+pub(crate) fn import_cli(
+    cli: &Path,
+    json: &Path,
+    out: &Path,
+    apng_out: Option<&Path>,
+) -> Result<()> {
+    fs::create_dir_all(out)?;
+    let status = Command::new(cli).arg(json).arg(out).status()?;
+    if !status.success() {
+        return Err(anyhow!("lottie-cli failed"));
+    }
+
+    let mut frames: Vec<_> = fs::read_dir(out)?
+        .filter_map(|e| {
+            let p = e.ok()?.path();
+            if p.extension().and_then(|ext| ext.to_str()) == Some("png") {
+                Some(p)
+            } else {
+                None
+            }
+        })
+        .collect();
+    frames.sort();
+
+    let delay = 100u16;
+    let timings: Vec<u16> = vec![delay; frames.len()];
+    fs::write(out.join("timing.json"), serde_json::to_vec(&timings)?)?;
+
+    if let Some(apng_path) = apng_out {
+        apng::run(out, apng_path, delay, 0)?;
+    }
+
+    println!(
+        "Imported {} frames using {} into {}",
+        frames.len(),
+        cli.display(),
+        out.display()
+    );
+    Ok(())
+}

--- a/src/bin/creator/scan.rs
+++ b/src/bin/creator/scan.rs
@@ -71,6 +71,7 @@ pub(crate) fn run(root: &Path, manifest_path: &Path) -> Result<()> {
                     path: rel_str.clone(),
                     hash: hash.clone(),
                     license: None,
+                    lottie: None,
                 });
                 changed.push(rel_str);
             }

--- a/src/bin/creator/snapshots/rlvgl_creator__apng__tests__apng_hashes.snap
+++ b/src/bin/creator/snapshots/rlvgl_creator__apng__tests__apng_hashes.snap
@@ -1,0 +1,6 @@
+---
+source: src/bin/creator/apng.rs
+expression: "format!(\"{}\\n{}\", apng_hash, first_hash)"
+---
+9b3e4252389fa440ed64cf792b0c7269e42420bdcc9d1a0fd8de0a77d7e59400
+f458113cfcb3e97b7ee939416c6fce913b5842cba07477db90887c854507b4a0

--- a/src/bin/creator/snapshots/rlvgl_creator__fonts__tests__font_hashes.snap
+++ b/src/bin/creator/snapshots/rlvgl_creator__fonts__tests__font_hashes.snap
@@ -1,0 +1,6 @@
+---
+source: src/bin/creator/fonts.rs
+expression: "format!(\"{}\\n{}\", bin_hash, json_hash)"
+---
+652cac0891936be91df5f7775a567234f7f543c6f54d1f232d72f0128b5de3ed
+8fe460aba6c13ade3e7ca8e7ad674e294c71228e9e0477991e67074cea169792

--- a/src/bin/creator/snapshots/rlvgl_creator__svg__tests__svg_hashes.snap
+++ b/src/bin/creator/snapshots/rlvgl_creator__svg__tests__svg_hashes.snap
@@ -1,0 +1,5 @@
+---
+source: src/bin/creator/svg.rs
+expression: "hash"
+---
+4afd9d2454855dc8557412527aa5a10170883fb8773f2127cb9929c51b0d51b4

--- a/src/bin/creator/svg.rs
+++ b/src/bin/creator/svg.rs
@@ -1,0 +1,79 @@
+//! SVG command for rlvgl-creator.
+//!
+//! Renders an SVG file into one or more raw RGBA images at specific DPI values,
+//! optionally applying a monochrome threshold suitable for e-ink displays.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Result, anyhow};
+use resvg::render;
+use resvg::tiny_skia;
+use resvg::usvg::{Options, Tree};
+
+use crate::raw;
+
+/// Render an SVG into raw RGBA images.
+pub(crate) fn run(svg: &Path, out: &Path, dpis: &[f32], threshold: Option<u8>) -> Result<()> {
+    let data = fs::read(svg)?;
+    let name = svg
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow!("invalid SVG name"))?;
+
+    for dpi in dpis {
+        let mut opt = Options::default();
+        opt.dpi = *dpi;
+        let tree = Tree::from_data(&data, &opt)?;
+        let size = tree.size().to_int_size();
+        let mut pixmap = tiny_skia::Pixmap::new(size.width(), size.height())
+            .ok_or_else(|| anyhow!("invalid SVG size"))?;
+        render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
+        let mut img =
+            image::RgbaImage::from_raw(size.width(), size.height(), pixmap.data().to_vec())
+                .ok_or_else(|| anyhow!("bad pixmap data"))?;
+
+        if let Some(th) = threshold {
+            for p in img.pixels_mut() {
+                let gray = (0.299 * p[0] as f32 + 0.587 * p[1] as f32 + 0.114 * p[2] as f32) as u8;
+                let v = if gray > th { 0xFF } else { 0x00 };
+                *p = image::Rgba([v, v, v, p[3]]);
+            }
+        }
+
+        fs::create_dir_all(out)?;
+        let out_path = out.join(format!("{name}_{dpi}dpi.raw"));
+        raw::encode_image(image::DynamicImage::ImageRgba8(img), &out_path)?;
+        println!(
+            "Rendered {} at {} DPI -> {}",
+            svg.display(),
+            dpi,
+            out_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blake3::hash;
+    use tempfile::tempdir;
+
+    #[test]
+    fn svg_renders_with_stable_hash() {
+        let dir = tempdir().unwrap();
+        let svg_path = dir.path().join("test.svg");
+        fs::write(
+            &svg_path,
+            "<svg width=\"2\" height=\"2\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"2\" height=\"2\" fill=\"#010203\"/></svg>",
+        )
+        .unwrap();
+        let out_dir = dir.path().join("out");
+        run(&svg_path, &out_dir, &[96.0], None).unwrap();
+        let data = fs::read(out_dir.join("test_96dpi.raw")).unwrap();
+        let hash = hash(&data).to_hex();
+        insta::assert_snapshot!("svg_hashes", hash);
+    }
+}


### PR DESCRIPTION
## Summary
- support per-target hardware presets in creator manifest
- show preset usage in assets-pack example manifest
- mark target preset task complete in creator TODO
- allow per-asset Lottie handling (direct or APNG) in manifest
- demonstrate Lottie handling in example asset manifest
- mark Lottie mode task complete in creator TODO
- add `lottie import` command to generate frames/APNG and timing map
- record `lottie import` completion in TODO
- support external `lottie-cli` conversions alongside FFI-based importer
- mark external CLI Lottie task complete in creator TODO
- enforce license presence and file-size limits via `creator check`
- record `creator check` completion in TODO
- cache conversions by content hash to skip unchanged assets
- mark cache task complete in creator TODO
- allow forcing asset reconversion and smart mtime-based rebuilds
- mark `--force` rebuild task complete in creator TODO
- parallelize asset conversions with rayon while preserving ordering
- note parallel conversions in README and TODO
- document creator templates and pipeline hooks
- mark developer docs task complete in creator TODO
- run creator pipeline end-to-end in CI and mark task done in TODO
- add snapshot-based tests for APNG timing and font packing
- mark golden test task complete in creator TODO
- render SVG images into raw sequences with optional monochrome threshold
- document the `svg` command and mark SVG conversion task complete in TODO

## Testing
- `cargo fmt --all -- --check`
- `cargo test --bin rlvgl-creator --no-default-features --features creator -- svg`
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_689d071059ac8333918fad7cbb1deb00