### PR TITLE
Add base rlvgl-micropython crate and shared API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ optional = true
 [dev-dependencies]
 insta = "1"
 tempfile = "3"
+panic-halt = "1.0.0"
 
 [features]
 default = []
@@ -199,9 +200,6 @@ creator = [
     "dep:resvg",
 ]
 
-[dev-dependencies]
-panic-halt = "1.0.0"
-
 [profile.release]
 opt-level = "z"
 lto = true
@@ -217,5 +215,5 @@ debug = true
 incremental = false
 
 [workspace]
-members = ["core", "platform", "widgets", "ui"]
+members = ["core", "platform", "widgets", "ui", "api", "micropython"]
 resolver = "2"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rlvgl-api"
+version = "0.1.0"
+edition = "2024"
+authors = ["Ira Abbott <ira@softobotos.com>"]
+license = "MIT"
+description = "Shared API types for rlvgl bindings"
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = []
+

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,3 +12,9 @@ path = "src/lib.rs"
 [features]
 default = []
 
+# Target environment feature flags
+micropython = []
+cpython = []
+cm4 = []
+sim = []
+

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -2,6 +2,12 @@
 #![deny(missing_docs)]
 
 //! Shared API definitions for rlvgl bindings.
+//!
+//! This crate is feature-flagged for multiple environments:
+//! - `micropython`
+//! - `cpython`
+//! - `cm4`
+//! - `sim`
 
 /// Z-index for stacking nodes.
 pub type ZIndex = i16;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![deny(missing_docs)]
+
+//! Shared API definitions for rlvgl bindings.
+
+/// Z-index for stacking nodes.
+pub type ZIndex = i16;
+
+/// Supported node kinds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NodeKind {
+    /// Solid rectangle node.
+    Rect,
+    /// Text label node.
+    Text,
+}
+
+/// Minimal node specification.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NodeSpec {
+    /// Node type.
+    pub kind: NodeKind,
+}
+
+/// Supported input event kinds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum InputKind {
+    /// A press or touch event.
+    Press,
+    /// A release or end of touch.
+    Release,
+}
+
+/// Minimal input event representation.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InputEvent {
+    /// Kind of the event.
+    pub kind: InputKind,
+}

--- a/docs/TODO-MICROPYTHON-DISCO.md
+++ b/docs/TODO-MICROPYTHON-DISCO.md
@@ -81,7 +81,7 @@
 | --- | --------------------------------- | ---------------------------- | -------------------------------------------------- |
 | [x] | Define public API structs (C‑ABI) | Rust `#[repr(C)]`            | `InputEvent`, `NodeSpec` minimal first             |
 | [x] | Rust FFI functions                | `extern "C"`                 | `mp_rlvgl_notify_input`, `mp_rlvgl_stack_add`, ... |
-| [ ] | MicroPython module table + stubs  | `mp_obj_module_t`            | Small C wrapper that forwards to Rust              |
+| [x] | MicroPython module table + stubs  | `mp_obj_module_t`            | Small C wrapper that forwards to Rust              |
 | [ ] | Build system glue                 | MP `ports/stm32` makefiles   | Add Rust static lib + link flags                   |
 | [ ] | Error mapping                     | status→`mp_raise_ValueError` | Never let Rust panic across ABI                    |
 | [ ] | Basic smoke test from REPL        | MicroPython                  | Add/remove a solid‑color rect, call `present()`    |

--- a/docs/TODO-MICROPYTHON-DISCO.md
+++ b/docs/TODO-MICROPYTHON-DISCO.md
@@ -80,7 +80,7 @@
 | ✓   | Description                       | Dependencies                 | Notes                                              |
 | --- | --------------------------------- | ---------------------------- | -------------------------------------------------- |
 | [x] | Define public API structs (C‑ABI) | Rust `#[repr(C)]`            | `InputEvent`, `NodeSpec` minimal first             |
-| [ ] | Rust FFI functions                | `extern "C"`                 | `mp_rlvgl_notify_input`, `mp_rlvgl_stack_add`, ... |
+| [x] | Rust FFI functions                | `extern "C"`                 | `mp_rlvgl_notify_input`, `mp_rlvgl_stack_add`, ... |
 | [ ] | MicroPython module table + stubs  | `mp_obj_module_t`            | Small C wrapper that forwards to Rust              |
 | [ ] | Build system glue                 | MP `ports/stm32` makefiles   | Add Rust static lib + link flags                   |
 | [ ] | Error mapping                     | status→`mp_raise_ValueError` | Never let Rust panic across ABI                    |
@@ -116,7 +116,7 @@ ui.present()
 | ✓   | Description                                           | Dependencies                | Notes                                     |
 | --- | ----------------------------------------------------- | --------------------------- | ----------------------------------------- |
 | [x] | Create `rlvgl_api` crate with `no_std` core types     | `serde` (optional), `alloc` | `InputEvent`, `NodeSpec`, `ZIndex`        |
-| [ ] | Feature flags: `micropython`, `cpython`, `cm4`, `sim` | Cargo features              | Guard per‑env specifics                   |
+| [x] | Feature flags: `micropython`, `cpython`, `cm4`, `sim` | Cargo features              | Guard per‑env specifics                   |
 | [ ] | Stability & versioning                                | SemVer                      | This is the top‑level API for both worlds |
 
 ---

--- a/docs/TODO-MICROPYTHON-DISCO.md
+++ b/docs/TODO-MICROPYTHON-DISCO.md
@@ -17,6 +17,9 @@
   - `stack_clear()`
   - `present()` (optional frame boundary)
   - `stats()` (optional)
+- **Crate layout:** `rlvgl-micropython` is a universal crate. Board‑specific
+  adaptations, such as STM32H747I‑DISCO, live behind feature flags like
+  `stm32h747i_disco`.
 
 ---
 
@@ -76,7 +79,7 @@
 
 | ✓   | Description                       | Dependencies                 | Notes                                              |
 | --- | --------------------------------- | ---------------------------- | -------------------------------------------------- |
-| [ ] | Define public API structs (C‑ABI) | Rust `#[repr(C)]`            | `InputEvent`, `NodeSpec` minimal first             |
+| [x] | Define public API structs (C‑ABI) | Rust `#[repr(C)]`            | `InputEvent`, `NodeSpec` minimal first             |
 | [ ] | Rust FFI functions                | `extern "C"`                 | `mp_rlvgl_notify_input`, `mp_rlvgl_stack_add`, ... |
 | [ ] | MicroPython module table + stubs  | `mp_obj_module_t`            | Small C wrapper that forwards to Rust              |
 | [ ] | Build system glue                 | MP `ports/stm32` makefiles   | Add Rust static lib + link flags                   |
@@ -112,7 +115,7 @@ ui.present()
 
 | ✓   | Description                                           | Dependencies                | Notes                                     |
 | --- | ----------------------------------------------------- | --------------------------- | ----------------------------------------- |
-| [ ] | Create `rlvgl_api` crate with `no_std` core types     | `serde` (optional), `alloc` | `InputEvent`, `NodeSpec`, `ZIndex`        |
+| [x] | Create `rlvgl_api` crate with `no_std` core types     | `serde` (optional), `alloc` | `InputEvent`, `NodeSpec`, `ZIndex`        |
 | [ ] | Feature flags: `micropython`, `cpython`, `cm4`, `sim` | Cargo features              | Guard per‑env specifics                   |
 | [ ] | Stability & versioning                                | SemVer                      | This is the top‑level API for both worlds |
 

--- a/micropython/Cargo.toml
+++ b/micropython/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rlvgl-micropython"
+version = "0.1.0"
+edition = "2024"
+authors = ["Ira Abbott <ira@softobotos.com>"]
+license = "MIT"
+description = "MicroPython bindings for rlvgl"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+rlvgl-api = { path = "../api", version = "0.1.0" }
+
+[features]
+default = []
+stm32h747i_disco = []
+

--- a/micropython/mp_module.c
+++ b/micropython/mp_module.c
@@ -1,0 +1,63 @@
+/*!
+ * MicroPython module registration for rlvgl.
+ *
+ * Provides placeholder bindings that forward to the Rust FFI.
+ * Board-specific behavior lives behind Cargo feature flags in
+ * the Rust crate; this C shim only wires the module table and
+ * basic call stubs.
+ */
+
+#include "py/obj.h"
+#include "py/runtime.h"
+
+// Forward declarations of the Rust FFI functions.
+void mp_rlvgl_init(void);
+void mp_rlvgl_stack_clear(void);
+void mp_rlvgl_present(void);
+void mp_rlvgl_stats(void);
+
+// Python-exposed wrappers.
+STATIC mp_obj_t mp_rlvgl_init_py(void) {
+    mp_rlvgl_init();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_rlvgl_init_obj, mp_rlvgl_init_py);
+
+STATIC mp_obj_t mp_rlvgl_stack_clear_py(void) {
+    mp_rlvgl_stack_clear();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_rlvgl_stack_clear_obj, mp_rlvgl_stack_clear_py);
+
+STATIC mp_obj_t mp_rlvgl_present_py(void) {
+    mp_rlvgl_present();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_rlvgl_present_obj, mp_rlvgl_present_py);
+
+STATIC mp_obj_t mp_rlvgl_stats_py(void) {
+    mp_rlvgl_stats();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_rlvgl_stats_obj, mp_rlvgl_stats_py);
+
+// Module globals table.
+STATIC const mp_rom_map_elem_t mp_rlvgl_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_mp_rlvgl) },
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&mp_rlvgl_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stack_clear), MP_ROM_PTR(&mp_rlvgl_stack_clear_obj) },
+    { MP_ROM_QSTR(MP_QSTR_present), MP_ROM_PTR(&mp_rlvgl_present_obj) },
+    { MP_ROM_QSTR(MP_QSTR_stats), MP_ROM_PTR(&mp_rlvgl_stats_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(mp_rlvgl_module_globals, mp_rlvgl_module_globals_table);
+
+// Define the module.
+const mp_obj_module_t mp_rlvgl_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&mp_rlvgl_module_globals,
+};
+
+// Register the module to make it available in MicroPython.
+MP_REGISTER_MODULE(MP_QSTR_mp_rlvgl, mp_rlvgl_user_cmodule);
+

--- a/micropython/src/lib.rs
+++ b/micropython/src/lib.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![deny(missing_docs)]
+
+//! MicroPython bindings for rlvgl.
+//!
+//! This crate is platform-agnostic; board-specific integrations such as
+//! STM32H747I-DISCO are enabled through feature flags.
+
+use rlvgl_api::{InputEvent, NodeSpec, ZIndex};
+
+/// Initialize the MicroPython binding.
+pub fn init() {}
+
+/// Notify an input event from the platform layer.
+///
+/// # Parameters
+/// - `event`: The input event to forward.
+pub fn notify_input(_event: InputEvent) {}
+
+/// Add a node to the display stack.
+///
+/// # Parameters
+/// - `z`: Z-index layer.
+/// - `node`: The node to add.
+pub fn stack_add(_z: ZIndex, _node: NodeSpec) {}

--- a/micropython/src/lib.rs
+++ b/micropython/src/lib.rs
@@ -23,3 +23,73 @@ pub fn notify_input(_event: InputEvent) {}
 /// - `z`: Z-index layer.
 /// - `node`: The node to add.
 pub fn stack_add(_z: ZIndex, _node: NodeSpec) {}
+
+/// Remove a node at a given z-index.
+///
+/// # Parameters
+/// - `z`: Z-index layer to remove.
+pub fn stack_remove(_z: ZIndex) {}
+
+/// Replace the node at a given z-index.
+///
+/// # Parameters
+/// - `z`: Z-index layer.
+/// - `node`: Replacement node.
+pub fn stack_replace(_z: ZIndex, _node: NodeSpec) {}
+
+/// Clear the entire display stack.
+pub fn stack_clear() {}
+
+/// Present the current frame boundary.
+pub fn present() {}
+
+/// Retrieve statistics for debugging.
+pub fn stats() {}
+
+/// C-ABI: initialize the binding.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_init() {
+    init();
+}
+
+/// C-ABI: forward an input event.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_notify_input(event: InputEvent) {
+    notify_input(event);
+}
+
+/// C-ABI: add a node to the display stack.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_stack_add(z: ZIndex, node: NodeSpec) {
+    stack_add(z, node);
+}
+
+/// C-ABI: remove a node from the display stack.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_stack_remove(z: ZIndex) {
+    stack_remove(z);
+}
+
+/// C-ABI: replace a node in the display stack.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_stack_replace(z: ZIndex, node: NodeSpec) {
+    stack_replace(z, node);
+}
+
+/// C-ABI: clear the display stack.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_stack_clear() {
+    stack_clear();
+}
+
+/// C-ABI: present the current frame.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_present() {
+    present();
+}
+
+/// C-ABI: retrieve statistics.
+#[unsafe(no_mangle)]
+pub extern "C" fn mp_rlvgl_stats() {
+    stats();
+}


### PR DESCRIPTION
## Summary
- add `rlvgl-api` crate with minimal cross-language structs
- introduce universal `rlvgl-micropython` crate with DISCO feature flag
- note crate layout and check off completed tasks in MicroPython TODO

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh` *(fails: terminated due to long build)*

------
https://chatgpt.com/codex/tasks/task_e_689f5fb7e6f88333bdec977f50418e07