### PR TITLE
feat: prompt to create or select manifest in creator UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,10 @@ optional = true
 version = "6"
 optional = true
 
+[dependencies.rfd]
+version = "0.15"
+optional = true
+
 [dev-dependencies]
 insta = "1"
 tempfile = "3"
@@ -229,6 +233,7 @@ creator_ui = [
     "dep:png",
     "dep:open",
     "dep:notify",
+    "dep:rfd",
 ]
 
 [profile.release]

--- a/examples/stm32h747i-disco/src/main.rs
+++ b/examples/stm32h747i-disco/src/main.rs
@@ -15,6 +15,7 @@ use embedded_alloc::Heap;
 #[cfg(target_os = "none")]
 #[cfg(not(doc))]
 use panic_halt as _;
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 use rlvgl::platform::stm32h747i_disco::Stm32h747iDiscoInput;
 
 #[path = "../../common_demo/lib.rs"]
@@ -41,6 +42,7 @@ fn main() -> ! {
     }
 
     // TODO: initialize `Stm32h747iDiscoDisplay` with a concrete blitter
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     let _touch = Stm32h747iDiscoInput;
     let _demo = build_demo();
 

--- a/src/bin/creator_ui/ui.rs
+++ b/src/bin/creator_ui/ui.rs
@@ -17,6 +17,7 @@ use eframe::{App, NativeOptions, egui};
 use egui::{ColorImage, TextureHandle, Vec2};
 use image::{GenericImageView, ImageFormat};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use rfd::{FileDialog, MessageButtons, MessageDialog, MessageDialogResult};
 use serde_yaml::from_reader;
 
 #[path = "../creator/apng.rs"]
@@ -46,10 +47,69 @@ const SCREEN_PRESETS: &[ScreenPreset] = &[ScreenPreset {
 }];
 
 /// Launch the rlgvl-creator desktop interface.
+///
+/// If no manifest is provided via command line or found in the current
+/// directory, the user is prompted to create or browse for a manifest file.
+/// Selecting a manifest in another directory updates the process working
+/// directory.
 pub fn run() -> Result<()> {
-    let manifest_path = std::env::args()
+    let mut manifest_path = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "manifest.yml".into());
+
+    if !Path::new(&manifest_path).exists() {
+        let choice = MessageDialog::new()
+            .set_title("manifest.yml not found")
+            .set_description("Create a new manifest, browse for an existing one, or cancel?")
+            .set_buttons(MessageButtons::YesNoCancel)
+            .show();
+
+        match choice {
+            MessageDialogResult::Yes => {
+                // Browse for manifest; allow creation in dialog.
+                loop {
+                    if let Some(path) = FileDialog::new()
+                        .add_filter("manifest", &["yml"])
+                        .set_file_name("manifest.yml")
+                        .pick_file()
+                    {
+                        if path
+                            .file_name()
+                            .map(|n| n == "manifest.yml")
+                            .unwrap_or(false)
+                        {
+                            if !path.exists() {
+                                let yaml = serde_yaml::to_string(&manifest::Manifest::default())?;
+                                fs::write(&path, format!("# rlvgl-creator manifest v1\n{}", yaml))?;
+                            }
+                            if let Some(parent) = path.parent() {
+                                std::env::set_current_dir(parent)?;
+                            }
+                            manifest_path = path.to_string_lossy().into_owned();
+                            break;
+                        } else {
+                            MessageDialog::new()
+                                .set_title("Invalid file")
+                                .set_description("Only manifest.yml is allowed")
+                                .set_buttons(MessageButtons::Ok)
+                                .show();
+                        }
+                    } else {
+                        return Ok(());
+                    }
+                }
+            }
+            MessageDialogResult::No => {
+                let yaml = serde_yaml::to_string(&manifest::Manifest::default())?;
+                fs::write(
+                    &manifest_path,
+                    format!("# rlvgl-creator manifest v1\n{}", yaml),
+                )?;
+            }
+            _ => return Ok(()),
+        }
+    }
+
     let file = File::open(Path::new(&manifest_path))?;
     let manifest: manifest::Manifest = from_reader(file)?;
 


### PR DESCRIPTION
## Summary
- add optional `rfd` dependency for file dialogs
- prompt to create or browse for a manifest when launching the creator UI
- gate STM32H747I-DISCO example import to avoid unresolved builds on non-ARM targets

## Testing
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00ae606308333b806a4c748455f73