### PR TITLE
Request initial redraw in simulator

### DIFF
--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -36,13 +36,13 @@ pub mod st7789;
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub mod stm32h747i_disco;
-#[cfg(feature = "simulator")]
-pub mod wgpu_blitter;
 #[cfg(all(
     feature = "stm32h747i_disco",
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub mod stm32h747i_disco_sd;
+#[cfg(feature = "simulator")]
+pub mod wgpu_blitter;
 
 pub use blit::{
     BlitCaps, BlitPlanner, Blitter, BlitterRenderer, PixelFmt, Rect as BlitRect, Surface,
@@ -68,10 +68,10 @@ pub use st7789::St7789Display;
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub use stm32h747i_disco::{Stm32h747iDiscoDisplay, Stm32h747iDiscoInput};
-#[cfg(feature = "simulator")]
-pub use wgpu_blitter::WgpuBlitter;
 #[cfg(all(
     feature = "stm32h747i_disco",
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub use stm32h747i_disco_sd::DiscoSdBlockDevice;
+#[cfg(feature = "simulator")]
+pub use wgpu_blitter::WgpuBlitter;

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -266,6 +266,10 @@ impl WgpuDisplay {
             mut state,
         } = self;
         event_loop.set_control_flow(ControlFlow::Poll);
+        // Request an initial redraw so the window displays its first frame
+        // immediately on creation. Without this, some platforms may present
+        // a blank window until the next event triggers a redraw.
+        window.request_redraw();
 
         let mut pointer_pos = (0i32, 0i32);
         let mut pointer_down = false;


### PR DESCRIPTION
## Summary
- ensure simulator window requests a redraw before entering the event loop so the first frame is rendered immediately
- reorder `wgpu_blitter` declarations to satisfy rustfmt

## Testing
- `cargo fmt --all -- --check`
- `cargo check -p rlvgl-platform --features simulator`
- `timeout 5 ./scripts/pre-commit.sh` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e967cd008333a8c6f7967c59f30d