### PR TITLE
feat(sim): add screen option

### DIFF
--- a/examples/sim/README.md
+++ b/examples/sim/README.md
@@ -2,6 +2,18 @@
 ---
 Demonstrates core widgets alongside plugin features such as QR code generation
 and PNG/JPEG image decoding.
+
+## Usage
+
+Run the simulator with a custom screen resolution using:
+
+```bash
+cargo run --bin rlvgl-sim -- --screen=800x480
+```
+
+Omit `--screen` to use the default 320x240 resolution. Pass a file path as an
+additional argument to export a single frame to a PNG instead of launching the
+interactive window.
 ## Requirements
 The rlvgl demo requires libgtk-3-dev and librlotte-dev for display and support of Lottie creation (Not implemented).
 

--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -7,8 +7,10 @@ use rlvgl::platform::{
 };
 use std::env;
 
-const WIDTH: usize = 320;
-const HEIGHT: usize = 240;
+/// Default screen width in pixels.
+const DEFAULT_WIDTH: usize = 320;
+/// Default screen height in pixels.
+const DEFAULT_HEIGHT: usize = 240;
 
 fn main() {
     let demo = build_demo();
@@ -16,16 +18,41 @@ fn main() {
     let pending = demo.pending.clone();
     let to_remove = demo.to_remove.clone();
 
+    let mut width = DEFAULT_WIDTH;
+    let mut height = DEFAULT_HEIGHT;
+    let mut path = None;
+
+    for arg in env::args().skip(1) {
+        if let Some(screen) = arg.strip_prefix("--screen=") {
+            if let Some((w, h)) = screen.split_once('x') {
+                if let (Ok(w), Ok(h)) = (w.parse::<usize>(), h.parse::<usize>()) {
+                    width = w;
+                    height = h;
+                } else {
+                    eprintln!("Invalid --screen value: {screen}");
+                    return;
+                }
+            } else {
+                eprintln!("Invalid --screen value: {screen}");
+                return;
+            }
+        } else {
+            path = Some(arg);
+        }
+    }
+
     let frame_cb = {
         let root = root.clone();
+        let width = width;
+        let height = height;
         move |frame: &mut [u8]| {
             let mut blitter = WgpuBlitter::new();
             let surface = Surface::new(
                 frame,
-                WIDTH * 4,
+                width * 4,
                 PixelFmt::Argb8888,
-                WIDTH as u32,
-                HEIGHT as u32,
+                width as u32,
+                height as u32,
             );
             let mut renderer: BlitterRenderer<'_, WgpuBlitter, 16> =
                 BlitterRenderer::new(&mut blitter, surface);
@@ -33,19 +60,19 @@ fn main() {
             renderer.planner().add(BlitRect {
                 x: 0,
                 y: 0,
-                w: WIDTH as u32,
-                h: HEIGHT as u32,
+                w: width as u32,
+                h: height as u32,
             });
         }
     };
 
-    if let Some(path) = env::args().nth(1) {
+    if let Some(path) = path {
         flush_pending(&root, &pending, &to_remove);
-        WgpuDisplay::headless(WIDTH, HEIGHT, frame_cb, path).expect("PNG dump failed");
+        WgpuDisplay::headless(width, height, frame_cb, path).expect("PNG dump failed");
         return;
     }
 
-    WgpuDisplay::new(WIDTH, HEIGHT).run(frame_cb, {
+    WgpuDisplay::new(width, height).run(frame_cb, {
         let root = root.clone();
         let pending = pending.clone();
         let to_remove = to_remove.clone();

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -36,13 +36,13 @@ pub mod st7789;
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub mod stm32h747i_disco;
-#[cfg(feature = "simulator")]
-pub mod wgpu_blitter;
 #[cfg(all(
     feature = "stm32h747i_disco",
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub mod stm32h747i_disco_sd;
+#[cfg(feature = "simulator")]
+pub mod wgpu_blitter;
 
 pub use blit::{
     BlitCaps, BlitPlanner, Blitter, BlitterRenderer, PixelFmt, Rect as BlitRect, Surface,
@@ -68,10 +68,10 @@ pub use st7789::St7789Display;
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub use stm32h747i_disco::{Stm32h747iDiscoDisplay, Stm32h747iDiscoInput};
-#[cfg(feature = "simulator")]
-pub use wgpu_blitter::WgpuBlitter;
 #[cfg(all(
     feature = "stm32h747i_disco",
     any(target_arch = "arm", target_arch = "aarch64")
 ))]
 pub use stm32h747i_disco_sd::DiscoSdBlockDevice;
+#[cfg(feature = "simulator")]
+pub use wgpu_blitter::WgpuBlitter;


### PR DESCRIPTION
## Summary
- add `--screen` CLI option to rlvgl-sim for custom resolutions
- document simulator usage and screen flag

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh` *(fails: build cancelled due to time)*
- `cargo test --tests --features "simulator qrcode png jpeg fontdue" -- examples/sim/tests/demo.rs` *(fails: build cancelled due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ea38d0f883339ea285d2eae2b1e0