### PR TITLE
Flush pending events before simulator run

### DIFF
--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
         return;
     }
 
+    flush_pending(&root, &pending, &to_remove);
     WgpuDisplay::new(WIDTH, HEIGHT).run(frame_cb, {
         let root = root.clone();
         let pending = pending.clone();


### PR DESCRIPTION
## Summary
- ensure simulator flushes pending widget updates before starting the event loop

## Testing
- `cargo fmt --all -- --check` (fails: format differences in unrelated files)
- `./scripts/pre-commit.sh`
- `cargo run --bin rlvgl-sim --features "simulator qrcode png jpeg fontdue" -- /tmp/output.png`
- `cargo run --bin rlvgl-sim --features "simulator qrcode png jpeg fontdue"` (fails: panicked at platform/src/simulator.rs:51:39)

------
https://chatgpt.com/codex/tasks/task_e_68a0e96502e883338291591cc5673adf