### PR TITLE
Pass framebuffer dimensions to simulator callbacks

### DIFF
--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -18,30 +18,25 @@ fn main() {
 
     let frame_cb = {
         let root = root.clone();
-        move |frame: &mut [u8]| {
+        move |frame: &mut [u8], w: usize, h: usize| {
             let mut blitter = WgpuBlitter::new();
-            let surface = Surface::new(
-                frame,
-                WIDTH * 4,
-                PixelFmt::Argb8888,
-                WIDTH as u32,
-                HEIGHT as u32,
-            );
+            let surface = Surface::new(frame, w * 4, PixelFmt::Argb8888, w as u32, h as u32);
             let mut renderer: BlitterRenderer<'_, WgpuBlitter, 16> =
                 BlitterRenderer::new(&mut blitter, surface);
             root.borrow().draw(&mut renderer);
             renderer.planner().add(BlitRect {
                 x: 0,
                 y: 0,
-                w: WIDTH as u32,
-                h: HEIGHT as u32,
+                w: w as u32,
+                h: h as u32,
             });
         }
     };
 
     if let Some(path) = env::args().nth(1) {
         flush_pending(&root, &pending, &to_remove);
-        WgpuDisplay::headless(WIDTH, HEIGHT, frame_cb, path).expect("PNG dump failed");
+        WgpuDisplay::headless(WIDTH, HEIGHT, |fb| frame_cb(fb, WIDTH, HEIGHT), path)
+            .expect("PNG dump failed");
         return;
     }
 

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -251,11 +251,12 @@ impl WgpuDisplay {
     /// Run the simulator event loop.
     ///
     /// `frame_callback` is invoked whenever the window needs to be redrawn,
-    /// providing mutable access to the RGBA pixel buffer. `event_callback`
-    /// receives input events converted from the underlying `winit` window.
+    /// providing mutable access to the RGBA pixel buffer along with the current
+    /// framebuffer width and height. `event_callback` receives input events
+    /// converted from the underlying `winit` window.
     pub fn run(
         self,
-        mut frame_callback: impl FnMut(&mut [u8]) + 'static,
+        mut frame_callback: impl FnMut(&mut [u8], usize, usize) + 'static,
         mut event_callback: impl FnMut(InputEvent) + 'static,
     ) {
         let WgpuDisplay {
@@ -320,7 +321,9 @@ impl WgpuDisplay {
                     event: WindowEvent::RedrawRequested,
                     ..
                 } => {
-                    frame_callback(state.frame_mut());
+                    let w = state.config.width as usize;
+                    let h = state.config.height as usize;
+                    frame_callback(state.frame_mut(), w, h);
                     state.render();
                 }
                 Event::WindowEvent {


### PR DESCRIPTION
## Summary
- propagate current framebuffer width and height to the simulator frame callback
- use dynamic framebuffer dimensions in the simulator example surface and blit rectangle

## Testing
- `./scripts/pre-commit.sh`
- `cargo test --workspace --all-targets --features "canvas,fatfs,fontdue,gif,jpeg,nes,png,pinyin,qrcode,simulator" --target x86_64-unknown-linux-gnu` *(fails: unresolved import `rlvgl_platform::PixelsDisplay`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e9666ab48333beb18ef818cae9af