### PR TITLE
Fix STM32H747I-DISCO build warnings and example dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,8 @@ version = "0.7"
 features = ["critical-section-single-core"]
 optional = true
 
-[target.'cfg(target_os = "none")'.dependencies.panic-halt]
+
+[dependencies.panic-halt]
 version = "1.0.0"
 optional = true
 
@@ -177,7 +178,6 @@ optional = true
 [dev-dependencies]
 insta = "1"
 tempfile = "3"
-panic-halt = "1.0.0"
 
 [features]
 default = []
@@ -192,6 +192,7 @@ stm32h747i_disco = [
     "dep:cortex-m-rt",
     "dep:cortex-m",
     "dep:embedded-alloc",
+    "dep:panic-halt",
 ]
 fontdue = ["rlvgl-core/fontdue", "rlvgl-platform/fontdue", "dep:fontdue"]
 lottie = ["rlvgl-core/lottie", "dep:rlottie"]

--- a/examples/common_demo/lib.rs
+++ b/examples/common_demo/lib.rs
@@ -7,7 +7,9 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, format, rc::Rc, vec::Vec};
+#[cfg(any(feature = "png", feature = "jpeg"))]
+use alloc::boxed::Box;
+use alloc::{format, rc::Rc, vec::Vec};
 use core::cell::RefCell;
 
 #[cfg(feature = "jpeg")]
@@ -16,11 +18,15 @@ use rlvgl::core::jpeg;
 use rlvgl::core::png;
 #[cfg(feature = "qrcode")]
 use rlvgl::core::qrcode;
+#[cfg(any(feature = "png", feature = "jpeg"))]
+use rlvgl::core::widget::Color;
 use rlvgl::core::{
     WidgetNode,
-    widget::{Color, Rect, Widget},
+    widget::{Rect, Widget},
 };
-use rlvgl::widgets::{button::Button, container::Container, image::Image, label::Label};
+#[cfg(any(feature = "png", feature = "jpeg"))]
+use rlvgl::widgets::image::Image;
+use rlvgl::widgets::{button::Button, container::Container, label::Label};
 
 type WidgetHandle = Rc<RefCell<dyn Widget>>;
 type WidgetSlot = Rc<RefCell<Option<WidgetHandle>>>;
@@ -187,10 +193,7 @@ pub fn build_demo() -> Demo {
                     width: 100,
                     height: 110,
                 })));
-                let mut menu = WidgetNode {
-                    widget: menu_w.clone(),
-                    children: Vec::new(),
-                };
+                let mut children = Vec::new();
 
                 #[cfg(feature = "qrcode")]
                 {
@@ -218,7 +221,7 @@ pub fn build_demo() -> Demo {
                             }
                         });
                     }
-                    menu.children.push(WidgetNode {
+                    children.push(WidgetNode {
                         widget: qr_button,
                         children: Vec::new(),
                     });
@@ -252,7 +255,7 @@ pub fn build_demo() -> Demo {
                                 }
                             });
                     }
-                    menu.children.push(WidgetNode {
+                    children.push(WidgetNode {
                         widget: png_button,
                         children: Vec::new(),
                     });
@@ -286,12 +289,16 @@ pub fn build_demo() -> Demo {
                                 }
                             });
                     }
-                    menu.children.push(WidgetNode {
+                    children.push(WidgetNode {
                         widget: jpeg_button,
                         children: Vec::new(),
                     });
                 }
 
+                let menu = WidgetNode {
+                    widget: menu_w.clone(),
+                    children,
+                };
                 menu_ref.borrow_mut().replace(menu_w);
                 pending_add.borrow_mut().push(menu);
             }

--- a/examples/stm32h747i-disco/src/main.rs
+++ b/examples/stm32h747i-disco/src/main.rs
@@ -15,8 +15,6 @@ use embedded_alloc::Heap;
 #[cfg(target_os = "none")]
 #[cfg(not(doc))]
 use panic_halt as _;
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-use rlvgl::platform::stm32h747i_disco::Stm32h747iDiscoInput;
 
 #[path = "../../common_demo/lib.rs"]
 mod common_demo;
@@ -41,9 +39,8 @@ fn main() -> ! {
         ALLOC.init(start, HEAP_SIZE);
     }
 
-    // TODO: initialize `Stm32h747iDiscoDisplay` with a concrete blitter
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    let _touch = Stm32h747iDiscoInput;
+    // TODO: initialize `Stm32h747iDiscoDisplay` with a concrete blitter and
+    // touch input driver once the hardware integration is complete.
     let _demo = build_demo();
 
     loop {

--- a/platform/src/stm32h747i_disco.rs
+++ b/platform/src/stm32h747i_disco.rs
@@ -32,7 +32,7 @@ use stm32h7::stm32h747cm7::{DSIHOST, FMC, LTDC, RCC};
 /// Wraps a [`Blitter`] and configures LTDC/DSI clocks. The actual flush path is
 /// still unimplemented and will eventually transfer pixel data over MIPI-DSI.
 pub struct Stm32h747iDiscoDisplay<B: Blitter, BL = (), RST = ()> {
-    blitter: B,
+    _blitter: B,
     #[cfg(feature = "stm32h747i_disco")]
     backlight: BL,
     #[cfg(feature = "stm32h747i_disco")]
@@ -75,13 +75,13 @@ impl<B: Blitter, BL, RST> Stm32h747iDiscoDisplay<B, BL, RST> {
         // Ensure the panel is held in reset and the backlight is off
         let _ = reset.set_low();
         let mut disp = Self {
-            blitter,
+            _blitter: blitter,
             backlight,
             reset,
             ltdc,
             dsi,
         };
-        let _ = disp.backlight.set_duty_cycle(0);
+        disp.set_backlight(0);
         disp.reset_panel();
         Otm8009a::init(&mut disp.dsi);
         let fb = Self::init_sdram(fmc, rcc);

--- a/platform/src/stm32h747i_disco_sd.rs
+++ b/platform/src/stm32h747i_disco_sd.rs
@@ -30,7 +30,7 @@ impl DiscoSdBlockDevice {
             // SAFETY: Accessing the SCB registers is safe here because we have
             // exclusive access to the buffer and perform a full memory
             // barrier after touching the cache.
-            (&mut *(SCB::ptr() as *mut SCB)).invalidate_dcache_by_slice(buf);
+            (&mut *SCB::PTR.cast_mut()).invalidate_dcache_by_slice(buf);
         }
         asm::dmb();
     }
@@ -39,7 +39,7 @@ impl DiscoSdBlockDevice {
     fn clean(buf: &[u8]) {
         unsafe {
             // SAFETY: See rationale in [`Self::invalidate`].
-            (&mut *(SCB::ptr() as *mut SCB)).clean_dcache_by_slice(buf);
+            (&mut *SCB::PTR.cast_mut()).clean_dcache_by_slice(buf);
         }
         asm::dmb();
     }


### PR DESCRIPTION
## Summary
- replace deprecated SCB cache maintenance calls
- tidy STM32H747I-DISCO display driver and example
- conditionally import demo assets to silence unused warnings
- add optional panic-halt dependency for embedded builds

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a13fb1f738833389eb1fa31b6dc5a7