### PR TITLE
Fix STM32 cache ops and pre-commit build

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -20,3 +20,6 @@ RUSTDOCFLAGS="--cfg docsrs --cfg nightly" \
     cargo +nightly doc \
     --all-features \
     --no-deps --target x86_64-unknown-linux-gnu
+
+# Ensure the STM32H747I-DISCO example builds for its target
+RUSTFLAGS="" cargo build --target thumbv7em-none-eabihf --bin rlvgl-stm32h747i-disco --features stm32h747i_disco


### PR DESCRIPTION
## Summary
- fix SCB cache maintenance by using `cortex_m::Peripherals`
- run STM32H747I-DISCO example build in pre-commit script

## Testing
- `RUSTFLAGS="" cargo build --target thumbv7em-none-eabihf --bin rlvgl-stm32h747i-disco --features stm32h747i_disco`
- `scripts/pre-commit.sh` *(fails: terminated during dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68a144e223ac83339cf9c7af39f1e8e1