### PR TITLE
Flush WGPU queue before surface presentation

### DIFF
--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -194,6 +194,9 @@ impl WgpuState {
                 depth_or_array_layers: 1,
             },
         );
+        // Submit to ensure the texture write completes before presenting.
+        // Set a breakpoint on this line to verify submission and inspect errors.
+        self.queue.submit(std::iter::empty());
         output.present();
     }
 


### PR DESCRIPTION
## Summary
- Ensure simulator flushes queue by submitting before presenting the surface

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh` *(terminated after extended build)*

------
https://chatgpt.com/codex/tasks/task_e_68a200db66f483338121d5e675061aad