### PR TITLE
Initialize wgpu logging for simulator

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -26,6 +26,7 @@ embedded-graphics = { version = "0.8", optional = true }
 image = { version = "0.24", default-features = false, features = ["png"], optional = true }
 bitflags = { version = "2", default-features = false }
 heapless = { version = "0.8", default-features = false }
+tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt"] }
 [target.'cfg(any(target_arch = "arm", target_arch = "aarch64"))'.dependencies]
 stm32h7 = { version = "0.16", optional = true, features = ["stm32h747cm7", "rt"] }
 stm32h7xx-hal = { version = "0.16", optional = true, features = ["stm32h747cm7", "sdmmc"] }
@@ -33,7 +34,7 @@ cortex-m = { version = "0.7", optional = true, features = ["critical-section-sin
 
 [features]
 default = []
-simulator = ["wgpu", "winit", "embedded-graphics", "eframe", "pollster", "image"]
+simulator = ["wgpu", "winit", "embedded-graphics", "eframe", "pollster", "image", "tracing-subscriber"]
 st7789 = ["embedded-hal", "display-interface", "display-interface-spi"]
 stm32h747i_disco = ["stm32h7", "embedded-hal", "stm32h7xx-hal", "cortex-m", "rlvgl-core/fs"]
 dma2d = ["stm32h7"]

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -12,6 +12,7 @@ use image::{ColorType, ImageError, save_buffer};
 use pollster::block_on;
 use rlvgl_core::event::Key;
 use std::{backtrace::Backtrace, eprintln, panic, path::Path};
+use tracing_subscriber::EnvFilter;
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{ElementState, Event, KeyEvent, MouseButton, WindowEvent},
@@ -21,6 +22,12 @@ use winit::{
 };
 
 use crate::input::InputEvent;
+
+/// Initialize logging for `wgpu` validation messages.
+fn init_wgpu_logger() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("wgpu=warn"));
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
 
 /// Display a panic message in a scrollable window limited to the screen size.
 fn show_panic_window(message: String) {
@@ -97,6 +104,7 @@ struct WgpuState {
 impl WgpuState {
     /// Create a new `wgpu` state for the given window and dimensions.
     fn new(window: &'static Window, width: u32, height: u32) -> Self {
+        init_wgpu_logger();
         let instance = wgpu::Instance::default();
         let surface = instance
             .create_surface(window)
@@ -116,6 +124,10 @@ impl WgpuState {
             None,
         ))
         .expect("failed to create device");
+        device.on_uncaptured_error(Box::new(|e| {
+            eprintln!("wgpu uncaptured error: {e:?}");
+            debug_assert!(false, "wgpu uncaptured error: {e:?}");
+        }));
         let caps = surface.get_capabilities(&adapter);
         let format = caps
             .formats
@@ -168,7 +180,9 @@ impl WgpuState {
     fn render(&mut self) {
         let output = match self.surface.get_current_texture() {
             Ok(frame) => frame,
-            Err(_) => {
+            Err(e) => {
+                eprintln!("surface error: {e:?}");
+                debug_assert!(false, "surface error: {e:?}");
                 self.surface.configure(&self.device, &self.config);
                 self.surface
                     .get_current_texture()


### PR DESCRIPTION
## Summary
- initialize tracing logger with wgpu warnings in simulator backend
- add debug breakpoints when wgpu surfaces or devices report errors

## Testing
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a200e4a3208333b6bc7382c69b04c0