### PR TITLE
Use wgpu for blitting

### DIFF
--- a/docs/TODO-PLUGGABLE-BLITTER.md
+++ b/docs/TODO-PLUGGABLE-BLITTER.md
@@ -71,7 +71,7 @@
 |---|---|---|---|
 | [x] | Replace/minimize `pixels/minifb` usage | `winit`, `wgpu` | `winit` window + `wgpu` swapchain. |
 | [x] | `WgpuBlitter` implementing `Blitter` | `wgpu` | Use render pass + textured quads or compute. |
-| [ ] | Upload tile/rect to texture; blit/blend in shader | `wgpu` | Match CPU/DMA2D semantics. |
+| [x] | Upload tile/rect to texture; blit/blend in shader | `wgpu` | Textures updated and blended via render pipelines. |
 | [x] | Present @ vsync; map keyboard/mouse → `InputDevice` | `winit` | DPI scaling; sRGB swapchain. |
 | [x] | Headless mode to dump PNGs for CI | `image` | Golden‑image regression tests. |
 

--- a/platform/src/wgpu_blitter.rs
+++ b/platform/src/wgpu_blitter.rs
@@ -1,19 +1,441 @@
-//! Software blitter used by the desktop simulator.
+//! GPU-accelerated blitter used by the desktop simulator.
 //!
-//! `WgpuBlitter` operates on RGBA pixel buffers and implements the
-//! [`Blitter`](crate::blit::Blitter) trait so widgets can render through the
-//! generic [`BlitterRenderer`](crate::blit::BlitterRenderer) before a GPU path
-//! is available.
+//! `WgpuBlitter` implements the [`Blitter`](crate::blit::Blitter) trait using
+//! the [`wgpu`](https://github.com/gfx-rs/wgpu) graphics API. Pixel operations
+//! such as filling, blitting and alpha blending are executed on the GPU by
+//! uploading surfaces to textures and rendering through small shader programs.
+//! Results are read back into the caller provided buffers so the remainder of
+//! the simulator can operate on plain memory.
 
 use crate::blit::{BlitCaps, Blitter, PixelFmt, Rect, Surface};
+use alloc::vec;
+use pollster::block_on;
 
-/// Simple blitter that writes pixels directly into a buffer.
-pub struct WgpuBlitter;
+/// Render based blitter that executes transfers on the GPU.
+pub struct WgpuBlitter {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    sampler: wgpu::Sampler,
+    tex_layout: wgpu::BindGroupLayout,
+    fill_layout: wgpu::BindGroupLayout,
+    blit_pipeline: wgpu::RenderPipeline,
+    blend_pipeline: wgpu::RenderPipeline,
+    fill_pipeline: wgpu::RenderPipeline,
+}
+
+// WGSL shader drawing a textured quad.
+const TEXTURE_SHADER: &str = r#"
+@group(0) @binding(0) var u_texture: texture_2d<f32>;
+@group(0) @binding(1) var u_sampler: sampler;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>;
+    @location(0) uv: vec2<f32>;
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VsOut {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(1.0, 1.0),
+    );
+    let p = positions[idx];
+    var out: VsOut;
+    out.pos = vec4<f32>(p * 2.0 - vec2<f32>(1.0, 1.0), 0.0, 1.0);
+    out.uv = p;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    return textureSample(u_texture, u_sampler, in.uv);
+}
+"#;
+
+// WGSL shader that fills with a solid colour.
+const FILL_SHADER: &str = r#"
+@group(0) @binding(0) var<uniform> u_color: vec4<f32>;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>;
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VsOut {
+    var positions = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(1.0, 1.0),
+    );
+    let p = positions[idx];
+    var out: VsOut;
+    out.pos = vec4<f32>(p * 2.0 - vec2<f32>(1.0, 1.0), 0.0, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_main(_in: VsOut) -> @location(0) vec4<f32> {
+    return u_color;
+}
+"#;
 
 impl WgpuBlitter {
-    /// Create a new blitter instance.
+    /// Create a new GPU blitter.
     pub fn new() -> Self {
-        Self
+        let instance = wgpu::Instance::default();
+        let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .expect("no suitable GPU adapters");
+        let (device, queue) = block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: None,
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_webgl2_defaults(),
+            },
+            None,
+        ))
+        .expect("device creation failed");
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor::default());
+
+        // Layout sampling from a texture.
+        let tex_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("texture-layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        // Layout containing a uniform colour buffer.
+        let fill_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("fill-layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let copy_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("copy-shader"),
+            source: wgpu::ShaderSource::Wgsl(TEXTURE_SHADER.into()),
+        });
+        let fill_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("fill-shader"),
+            source: wgpu::ShaderSource::Wgsl(FILL_SHADER.into()),
+        });
+
+        let tex_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("tex-pipeline-layout"),
+            bind_group_layouts: &[&tex_layout],
+            push_constant_ranges: &[],
+        });
+
+        let fill_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("fill-pipeline-layout"),
+            bind_group_layouts: &[&fill_layout],
+            push_constant_ranges: &[],
+        });
+
+        let color_state = wgpu::ColorTargetState {
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            blend: None,
+            write_mask: wgpu::ColorWrites::ALL,
+        };
+
+        let blit_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("blit-pipeline"),
+            layout: Some(&tex_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &copy_shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &copy_shader,
+                entry_point: "fs_main",
+                targets: &[Some(color_state.clone())],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        let blend_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("blend-pipeline"),
+            layout: Some(&tex_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &copy_shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &copy_shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    ..color_state
+                })],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        let fill_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("fill-pipeline"),
+            layout: Some(&fill_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &fill_shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &fill_shader,
+                entry_point: "fs_main",
+                targets: &[Some(color_state)],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        Self {
+            device,
+            queue,
+            sampler,
+            tex_layout,
+            fill_layout,
+            blit_pipeline,
+            blend_pipeline,
+            fill_pipeline,
+        }
+    }
+
+    // Upload an entire surface into a GPU texture.
+    fn upload_surface(&self, surf: &Surface) -> wgpu::Texture {
+        let extent = wgpu::Extent3d {
+            width: surf.width,
+            height: surf.height,
+            depth_or_array_layers: 1,
+        };
+        let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("surface"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+
+        let row_bytes = (surf.width as usize) * 4;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
+        if surf.stride == row_bytes && row_bytes % align == 0 {
+            self.queue.write_texture(
+                wgpu::ImageCopyTexture {
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                surf.buf,
+                wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(row_bytes as u32),
+                    rows_per_image: Some(surf.height),
+                },
+                extent,
+            );
+        } else {
+            let padded = ((row_bytes + align - 1) / align) * align;
+            let mut tmp = vec![0u8; padded * surf.height as usize];
+            for y in 0..surf.height as usize {
+                let src_off = y * surf.stride;
+                let dst_off = y * padded;
+                tmp[dst_off..dst_off + row_bytes]
+                    .copy_from_slice(&surf.buf[src_off..src_off + row_bytes]);
+            }
+            self.queue.write_texture(
+                wgpu::ImageCopyTexture {
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &tmp,
+                wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded as u32),
+                    rows_per_image: Some(surf.height),
+                },
+                extent,
+            );
+        }
+
+        texture
+    }
+
+    // Upload a rectangular region from a surface.
+    fn upload_area(&self, surf: &Surface, area: Rect) -> wgpu::Texture {
+        let extent = wgpu::Extent3d {
+            width: area.w,
+            height: area.h,
+            depth_or_array_layers: 1,
+        };
+        let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("tile"),
+            size: extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let bpp = 4usize;
+        let row_bytes = area.w as usize * bpp;
+        let mut data = vec![0u8; row_bytes * area.h as usize];
+        for y in 0..area.h as usize {
+            let src_off = (area.y as usize + y) * surf.stride + area.x as usize * bpp;
+            let dst_off = y * row_bytes;
+            data[dst_off..dst_off + row_bytes]
+                .copy_from_slice(&surf.buf[src_off..src_off + row_bytes]);
+        }
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
+        if row_bytes % align == 0 {
+            self.queue.write_texture(
+                wgpu::ImageCopyTexture {
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &data,
+                wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(row_bytes as u32),
+                    rows_per_image: Some(area.h),
+                },
+                extent,
+            );
+        } else {
+            let padded = ((row_bytes + align - 1) / align) * align;
+            let mut tmp = vec![0u8; padded * area.h as usize];
+            for y in 0..area.h as usize {
+                let src_off = y * row_bytes;
+                let dst_off = y * padded;
+                tmp[dst_off..dst_off + row_bytes]
+                    .copy_from_slice(&data[src_off..src_off + row_bytes]);
+            }
+            self.queue.write_texture(
+                wgpu::ImageCopyTexture {
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &tmp,
+                wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded as u32),
+                    rows_per_image: Some(area.h),
+                },
+                extent,
+            );
+        }
+        texture
+    }
+
+    // Read a texture back into a CPU surface.
+    fn download_surface(&self, tex: &wgpu::Texture, surf: &mut Surface) {
+        let row_bytes = surf.width as usize * 4;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
+        let padded = ((row_bytes + align - 1) / align) * align;
+        let size = padded * surf.height as usize;
+        let buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("readback"),
+            size: size as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                texture: tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer: &buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(padded as u32),
+                    rows_per_image: Some(surf.height),
+                },
+            },
+            wgpu::Extent3d {
+                width: surf.width,
+                height: surf.height,
+                depth_or_array_layers: 1,
+            },
+        );
+        self.queue.submit(Some(encoder.finish()));
+
+        let slice = buffer.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |_| {});
+        self.device.poll(wgpu::Maintain::Wait);
+        let data = slice.get_mapped_range();
+        for y in 0..surf.height as usize {
+            let src_off = y * padded;
+            let dst_off = y * surf.stride;
+            surf.buf[dst_off..dst_off + row_bytes]
+                .copy_from_slice(&data[src_off..src_off + row_bytes]);
+        }
+        drop(data);
+        buffer.unmap();
     }
 }
 
@@ -23,77 +445,190 @@ impl Blitter for WgpuBlitter {
     }
 
     fn fill(&mut self, dst: &mut Surface, area: Rect, color: u32) {
-        let r = ((color >> 16) & 0xff) as u8;
-        let g = ((color >> 8) & 0xff) as u8;
-        let b = (color & 0xff) as u8;
-        let a = ((color >> 24) & 0xff) as u8;
-        let x0 = area.x.max(0);
-        let y0 = area.y.max(0);
-        let x1 = (area.x + area.w as i32).min(dst.width as i32);
-        let y1 = (area.y + area.h as i32).min(dst.height as i32);
-        for y in y0..y1 {
-            for x in x0..x1 {
-                let idx = y as usize * dst.stride + x as usize * 4;
-                dst.buf[idx] = r;
-                dst.buf[idx + 1] = g;
-                dst.buf[idx + 2] = b;
-                dst.buf[idx + 3] = a;
-            }
+        if dst.format != PixelFmt::Argb8888 {
+            return;
         }
+        let dst_tex = self.upload_surface(dst);
+        let color_vec = [
+            ((color >> 16) & 0xff) as f32 / 255.0,
+            ((color >> 8) & 0xff) as f32 / 255.0,
+            (color & 0xff) as f32 / 255.0,
+            ((color >> 24) & 0xff) as f32 / 255.0,
+        ];
+        let color_bytes =
+            unsafe { core::slice::from_raw_parts(color_vec.as_ptr() as *const u8, 16) };
+        let color_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("color"),
+            size: 16,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        self.queue.write_buffer(&color_buf, 0, color_bytes);
+
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &self.fill_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: color_buf.as_entire_binding(),
+            }],
+            label: Some("fill-bind"),
+        });
+
+        let view = dst_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("fill-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.fill_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.set_viewport(0.0, 0.0, dst.width as f32, dst.height as f32, 0.0, 1.0);
+            let x = area.x.max(0) as u32;
+            let y = area.y.max(0) as u32;
+            pass.set_scissor_rect(x, y, area.w, area.h);
+            pass.draw(0..6, 0..1);
+        }
+        self.queue.submit(Some(encoder.finish()));
+        self.device.poll(wgpu::Maintain::Wait);
+        self.download_surface(&dst_tex, dst);
     }
 
     fn blit(&mut self, src: &Surface, src_area: Rect, dst: &mut Surface, dst_pos: (i32, i32)) {
         if src.format != PixelFmt::Argb8888 || dst.format != PixelFmt::Argb8888 {
             return;
         }
-        let bpp = 4usize;
-        for row in 0..src_area.h as i32 {
-            let sy = src_area.y + row;
-            let dy = dst_pos.1 + row;
-            if sy < 0 || dy < 0 || sy as u32 >= src.height || dy as u32 >= dst.height {
-                continue;
-            }
-            let src_offset = sy as usize * src.stride + src_area.x.max(0) as usize * bpp;
-            let dst_offset = dy as usize * dst.stride + dst_pos.0.max(0) as usize * bpp;
-            let width = src_area.w as usize * bpp;
-            dst.buf[dst_offset..dst_offset + width]
-                .copy_from_slice(&src.buf[src_offset..src_offset + width]);
+        let src_tex = self.upload_area(src, src_area);
+        let dst_tex = self.upload_surface(dst);
+        let src_view = src_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let bind = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &self.tex_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&src_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+            ],
+            label: Some("blit-bind"),
+        });
+        let dst_view = dst_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("blit-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &dst_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.blit_pipeline);
+            pass.set_bind_group(0, &bind, &[]);
+            pass.set_viewport(
+                dst_pos.0 as f32,
+                dst_pos.1 as f32,
+                src_area.w as f32,
+                src_area.h as f32,
+                0.0,
+                1.0,
+            );
+            pass.set_scissor_rect(
+                dst_pos.0.max(0) as u32,
+                dst_pos.1.max(0) as u32,
+                src_area.w,
+                src_area.h,
+            );
+            pass.draw(0..6, 0..1);
         }
+        self.queue.submit(Some(encoder.finish()));
+        self.device.poll(wgpu::Maintain::Wait);
+        self.download_surface(&dst_tex, dst);
     }
 
     fn blend(&mut self, src: &Surface, src_area: Rect, dst: &mut Surface, dst_pos: (i32, i32)) {
         if src.format != PixelFmt::Argb8888 || dst.format != PixelFmt::Argb8888 {
             return;
         }
-        let bpp = 4usize;
-        for row in 0..src_area.h as i32 {
-            let sy = src_area.y + row;
-            let dy = dst_pos.1 + row;
-            if sy < 0 || dy < 0 || sy as u32 >= src.height || dy as u32 >= dst.height {
-                continue;
-            }
-            for col in 0..src_area.w as i32 {
-                let sx = src_area.x + col;
-                let dx = dst_pos.0 + col;
-                if sx < 0 || dx < 0 || sx as u32 >= src.width || dx as u32 >= dst.width {
-                    continue;
-                }
-                let s_idx = sy as usize * src.stride + sx as usize * bpp;
-                let d_idx = dy as usize * dst.stride + dx as usize * bpp;
-                let sr = src.buf[s_idx] as u16;
-                let sg = src.buf[s_idx + 1] as u16;
-                let sb = src.buf[s_idx + 2] as u16;
-                let sa = src.buf[s_idx + 3] as u16;
-                let dr = dst.buf[d_idx] as u16;
-                let dg = dst.buf[d_idx + 1] as u16;
-                let db = dst.buf[d_idx + 2] as u16;
-                let da = dst.buf[d_idx + 3] as u16;
-                let inv_a = 255 - sa;
-                dst.buf[d_idx] = ((sr * sa + dr * inv_a) / 255) as u8;
-                dst.buf[d_idx + 1] = ((sg * sa + dg * inv_a) / 255) as u8;
-                dst.buf[d_idx + 2] = ((sb * sa + db * inv_a) / 255) as u8;
-                dst.buf[d_idx + 3] = da.max(sa) as u8;
-            }
+        let src_tex = self.upload_area(src, src_area);
+        let dst_tex = self.upload_surface(dst);
+        let src_view = src_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let bind = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &self.tex_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&src_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+            ],
+            label: Some("blend-bind"),
+        });
+        let dst_view = dst_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("blend-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &dst_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.blend_pipeline);
+            pass.set_bind_group(0, &bind, &[]);
+            pass.set_viewport(
+                dst_pos.0 as f32,
+                dst_pos.1 as f32,
+                src_area.w as f32,
+                src_area.h as f32,
+                0.0,
+                1.0,
+            );
+            pass.set_scissor_rect(
+                dst_pos.0.max(0) as u32,
+                dst_pos.1.max(0) as u32,
+                src_area.w,
+                src_area.h,
+            );
+            pass.draw(0..6, 0..1);
         }
+        self.queue.submit(Some(encoder.finish()));
+        self.device.poll(wgpu::Maintain::Wait);
+        self.download_surface(&dst_tex, dst);
     }
 }


### PR DESCRIPTION
## Summary
- replace CPU loops in `WgpuBlitter` with GPU shaders and texture uploads
- note completed GPU path in pluggable blitter TODO

## Testing
- `cargo check -p rlvgl-platform --features simulator`
- `./scripts/pre-commit.sh` *(fails: process terminated early due to resource limits)*

------
https://chatgpt.com/codex/tasks/task_e_68a2269f45048333aaf583e44a811c3f