### PR TITLE
Fix WGSL struct syntax to prevent simulator panic

### DIFF
--- a/platform/src/wgpu_blitter.rs
+++ b/platform/src/wgpu_blitter.rs
@@ -29,8 +29,8 @@ const TEXTURE_SHADER: &str = r#"
 @group(0) @binding(1) var u_sampler: sampler;
 
 struct VsOut {
-    @builtin(position) pos: vec4<f32>;
-    @location(0) uv: vec2<f32>;
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
 };
 
 @vertex
@@ -61,7 +61,7 @@ const FILL_SHADER: &str = r#"
 @group(0) @binding(0) var<uniform> u_color: vec4<f32>;
 
 struct VsOut {
-    @builtin(position) pos: vec4<f32>;
+    @builtin(position) pos: vec4<f32>,
 };
 
 @vertex


### PR DESCRIPTION
## Summary
- correct WGSL `VsOut` structures to use commas instead of semicolons

## Testing
- `cargo fmt --all -- --check`
- `cargo check -p rlvgl-platform`
- `./scripts/pre-commit.sh` *(fails: killed after long dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68a22a853c308333945ce733ba852b13