### PR TITLE
Reuse simulator blitter to avoid Metal context leaks

### DIFF
--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -71,10 +71,10 @@ fn main() {
         }
     }
 
+    let mut blitter = WgpuBlitter::new();
     let frame_cb = {
         let root = root.clone();
         move |frame: &mut [u8], w: usize, h: usize| {
-            let mut blitter = WgpuBlitter::new();
             let surface = Surface::new(frame, w * 4, PixelFmt::Argb8888, w as u32, h as u32);
             let mut renderer: BlitterRenderer<'_, WgpuBlitter, 16> =
                 BlitterRenderer::new(&mut blitter, surface);

--- a/platform/src/wgpu_blitter.rs
+++ b/platform/src/wgpu_blitter.rs
@@ -81,7 +81,7 @@ fn vs_main(@builtin(vertex_index) idx: u32) -> VsOut {
 }
 
 @fragment
-fn fs_main(_in: VsOut) -> @location(0) vec4<f32> {
+fn fs_main() -> @location(0) vec4<f32> {
     return u_color;
 }
 "#;


### PR DESCRIPTION
## Summary
- reuse a single `WgpuBlitter` in the simulator demo instead of recreating it every frame
- drop unused fragment input to silence Metal shader warnings

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a22f0bda008333848902211ac5f7f8