### PR TITLE
Fix simulator frame callback mutability

### DIFF
--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
     }
 
     let mut blitter = WgpuBlitter::new();
-    let frame_cb = {
+    let mut frame_cb = {
         let root = root.clone();
         move |frame: &mut [u8], w: usize, h: usize| {
             let surface = Surface::new(frame, w * 4, PixelFmt::Argb8888, w as u32, h as u32);

--- a/platform/src/simulator.rs
+++ b/platform/src/simulator.rs
@@ -190,7 +190,7 @@ impl WgpuState {
                     .expect("failed to acquire surface texture")
             }
         };
-       let frame_slice: Cow<[u8]> = match self.config.format {
+        let frame_slice: Cow<[u8]> = match self.config.format {
             wgpu::TextureFormat::Bgra8Unorm | wgpu::TextureFormat::Bgra8UnormSrgb => {
                 let mut converted = self.frame.clone();
                 for px in converted.chunks_exact_mut(4) {
@@ -200,6 +200,7 @@ impl WgpuState {
             }
             _ => Cow::Borrowed(&self.frame),
         };
+        let data = frame_slice.as_ref();
         let row_bytes = 4 * self.config.width as usize;
         let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
         if row_bytes % align == 0 {
@@ -210,7 +211,7 @@ impl WgpuState {
                     origin: wgpu::Origin3d::ZERO,
                     aspect: wgpu::TextureAspect::All,
                 },
-                &self.frame,
+                data,
                 wgpu::ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(row_bytes as u32),
@@ -229,7 +230,7 @@ impl WgpuState {
                 let src_off = y * row_bytes;
                 let dst_off = y * stride;
                 padded[dst_off..dst_off + row_bytes]
-                    .copy_from_slice(&self.frame[src_off..src_off + row_bytes]);
+                    .copy_from_slice(&data[src_off..src_off + row_bytes]);
             }
             self.queue.write_texture(
                 wgpu::ImageCopyTexture {


### PR DESCRIPTION
## Summary
- make simulator frame callback mutable
- use converted frame slice when writing textures in simulator

## Testing
- `./scripts/pre-commit.sh`
- `cargo build --bin=rlvgl-sim --features=simulator,fontdue,qrcode,png,jpeg`

------
https://chatgpt.com/codex/tasks/task_e_68a23627ee4883338249c6bf67c3081d