### PR TITLE
Return Result from draw_lottie_frame

### DIFF
--- a/core/src/plugins/lottie.rs
+++ b/core/src/plugins/lottie.rs
@@ -6,6 +6,13 @@
 use crate::widget::Color;
 use rlottie::{Animation, Size, Surface};
 
+/// Errors that can occur when rendering a Lottie animation frame.
+#[derive(Debug, Clone)]
+pub enum Error {
+    /// The provided Lottie JSON data was invalid.
+    InvalidJson,
+}
+
 /// Render a single frame of a Lottie JSON animation.
 ///
 /// * `json` - Lottie document as UTF-8 text.

--- a/platform/src/blit.rs
+++ b/platform/src/blit.rs
@@ -238,7 +238,7 @@ impl<'a, B: Blitter, const N: usize> BlitterRenderer<'a, B, N> {
     #[cfg(feature = "lottie")]
     /// Render a Lottie JSON animation frame and blit it onto the target surface.
     ///
-    /// Returns `true` if the frame was rendered successfully.
+    /// Returns an error if the JSON data is invalid.
     pub fn draw_lottie_frame(
         &mut self,
         position: (i32, i32),
@@ -246,15 +246,12 @@ impl<'a, B: Blitter, const N: usize> BlitterRenderer<'a, B, N> {
         frame: usize,
         width: u32,
         height: u32,
-    ) -> bool {
-        if let Some(pixels) =
+    ) -> Result<(), rlvgl_core::lottie::Error> {
+        let pixels =
             rlvgl_core::lottie::render_lottie_frame(json, frame, width as usize, height as usize)
-        {
-            self.blit_colors(position, &pixels, width, height);
-            true
-        } else {
-            false
-        }
+                .ok_or(rlvgl_core::lottie::Error::InvalidJson)?;
+        self.blit_colors(position, &pixels, width, height);
+        Ok(())
     }
 
     #[cfg(feature = "canvas")]
@@ -570,7 +567,9 @@ mod lottie_tests {
         let mut blit = CpuBlitter;
         let mut renderer: BlitterRenderer<'_, CpuBlitter, 4> =
             BlitterRenderer::new(&mut blit, surface);
-        assert!(renderer.draw_lottie_frame((0, 0), SIMPLE_JSON, 0, 1, 1));
+        renderer
+            .draw_lottie_frame((0, 0), SIMPLE_JSON, 0, 1, 1)
+            .unwrap();
         assert!(buf.iter().any(|&p| p != 0));
     }
 }


### PR DESCRIPTION
## Summary
- return `Result` from `draw_lottie_frame` and propagate invalid JSON
- expose a simple `lottie::Error` type
- adapt tests to the new `Result`-based API

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a3732a155083338e52f83e035ba3bf