### PR TITLE
test: add APNG blit test

### DIFF
--- a/platform/src/blit.rs
+++ b/platform/src/blit.rs
@@ -517,6 +517,29 @@ mod gif_tests {
     }
 }
 
+#[cfg(all(test, feature = "apng"))]
+mod apng_tests {
+    use super::*;
+    use crate::cpu_blitter::CpuBlitter;
+    use base64::Engine;
+
+    const RED_DOT_APNG: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACGFjVEwAAAABAAAAALQt6aAAAAAaZmNUTAAAAAAAAAABAAAAAQAAAAAAAAAAAGQD6AEAqmVSjAAAAA1JREFUeJxj+M/A8B8ABQAB/4mZPR0AAAAASUVORK5CYII=";
+
+    #[test]
+    fn blitter_draws_apng() {
+        let data = base64::engine::general_purpose::STANDARD
+            .decode(RED_DOT_APNG)
+            .unwrap();
+        let mut buf = [0u8; 4 * 4 * 4];
+        let surface = Surface::new(&mut buf, 4 * 4, PixelFmt::Argb8888, 4, 4);
+        let mut blit = CpuBlitter;
+        let mut renderer: BlitterRenderer<'_, CpuBlitter, 4> =
+            BlitterRenderer::new(&mut blit, surface);
+        renderer.draw_apng_frame((0, 0), &data, 0).unwrap();
+        assert!(buf.iter().any(|&p| p != 0));
+    }
+}
+
 #[cfg(all(test, feature = "canvas"))]
 mod canvas_tests {
     use super::*;


### PR DESCRIPTION
## Summary
- add APNG fixture and test to `BlitterRenderer`

## Testing
- `./scripts/pre-commit.sh`
- `cargo test -p rlvgl-platform --features apng` *(fails: byteorder build issues in embedded_size_regression)*
- `cargo test -p rlvgl-platform --features apng --lib`


------
https://chatgpt.com/codex/tasks/task_e_68a37360126483339f6097fbb5b80511