### PR TITLE
Make demo dimensions configurable

### DIFF
--- a/examples/common_demo/lib.rs
+++ b/examples/common_demo/lib.rs
@@ -101,11 +101,14 @@ pub struct Demo {
 
 /// Build a simple widget tree demonstrating basic rlvgl widgets.
 ///
+/// The demo is constructed with a root [`Container`] sized to `width` by
+/// `height` pixels.
+///
 /// Returns a [`Demo`] struct containing the root [`WidgetNode`], a counter
 /// incremented whenever the button is clicked, and a queue of widgets that
 /// should be appended to the root after event dispatch. A `Plugins` button is
 /// included to showcase optional features.
-pub fn build_demo() -> Demo {
+pub fn build_demo(width: i32, height: i32) -> Demo {
     let click_count = Rc::new(RefCell::new(0));
     let pending = Rc::new(RefCell::new(Vec::new()));
     let to_remove = Rc::new(RefCell::new(Vec::new()));
@@ -133,8 +136,8 @@ pub fn build_demo() -> Demo {
         widget: Rc::new(RefCell::new(Container::new(Rect {
             x: 0,
             y: 0,
-            width: 320,
-            height: 240,
+            width,
+            height,
         }))),
         children: Vec::new(),
     }));

--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -43,11 +43,6 @@ fn dump_ascii_frame(buffer: &[u8], width: usize, height: usize) -> String {
 }
 
 fn main() {
-    let demo = build_demo();
-    let root = demo.root.clone();
-    let pending = demo.pending.clone();
-    let to_remove = demo.to_remove.clone();
-
     let mut width = DEFAULT_WIDTH;
     let mut height = DEFAULT_HEIGHT;
     let mut path = None;
@@ -84,6 +79,11 @@ fn main() {
             path = Some(arg);
         }
     }
+
+    let demo = build_demo(width as i32, height as i32);
+    let root = demo.root.clone();
+    let pending = demo.pending.clone();
+    let to_remove = demo.to_remove.clone();
 
     let mut frame_cb = {
         let root = root.clone();

--- a/examples/sim/tests/demo.rs
+++ b/examples/sim/tests/demo.rs
@@ -59,7 +59,7 @@ impl Renderer for FramebufferRenderer {
 
 #[test]
 fn demo_draws_widgets() {
-    let Demo { root, .. } = build_demo();
+    let Demo { root, .. } = build_demo(320, 240);
     let mut renderer = CountRenderer(0);
     root.borrow().draw(&mut renderer);
     assert!(renderer.0 > 0);
@@ -72,7 +72,7 @@ fn button_click_increments_counter() {
         counter,
         pending,
         to_remove,
-    } = build_demo();
+    } = build_demo(320, 240);
     assert_eq!(*counter.borrow(), 0);
     assert!(
         root.borrow_mut()
@@ -124,7 +124,7 @@ fn plugins_button_adds_demo() {
         pending,
         to_remove,
         ..
-    } = build_demo();
+    } = build_demo(320, 240);
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 110, y: 50 })
@@ -145,7 +145,7 @@ fn png_button_adds_demo() {
         pending,
         to_remove,
         ..
-    } = build_demo();
+    } = build_demo(320, 240);
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 110, y: 50 })
@@ -166,7 +166,7 @@ fn jpeg_button_adds_demo() {
         pending,
         to_remove,
         ..
-    } = build_demo();
+    } = build_demo(320, 240);
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 110, y: 50 })
@@ -187,7 +187,7 @@ fn qr_button_toggles_qrcode() {
         pending,
         to_remove,
         ..
-    } = build_demo();
+    } = build_demo(320, 240);
     assert!(
         root.borrow_mut()
             .dispatch_event(&Event::PointerUp { x: 110, y: 50 })

--- a/examples/stm32h747i-disco/src/main.rs
+++ b/examples/stm32h747i-disco/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
 
     // TODO: initialize `Stm32h747iDiscoDisplay` with a concrete blitter and
     // touch input driver once the hardware integration is complete.
-    let _demo = build_demo();
+    let _demo = build_demo(480, 272);
 
     loop {
         cortex_m::asm::nop();


### PR DESCRIPTION
## Summary
- allow specifying desired width and height when building demo
- size the root container to the provided dimensions
- update simulator, hardware example, and tests to pass screen size

## Testing
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a38a5d5a7c8333877861a322a7ec90