### PR TITLE
Scale oversized simulator surfaces

### DIFF
--- a/examples/sim/README.md
+++ b/examples/sim/README.md
@@ -19,6 +19,13 @@ export a single frame to a PNG instead of launching the interactive window.
 For asset management workflows using `rlvgl-creator`, see
 [`README-CREATOR.md`](../../README-CREATOR.md).
 
+## Limitations
+
+On displays that exceed the GPU's maximum texture size, the simulator
+renders to a smaller internal framebuffer and scales the result to fit the
+window. This scaling can introduce letterboxing or reduced sharpness on
+ultra-high-resolution monitors.
+
 ## Requirements
 The rlvgl demo requires libgtk-3-dev and librlotte-dev for display and support of Lottie creation (Not implemented).
 


### PR DESCRIPTION
## Summary
- scale simulator framebuffer when window exceeds GPU texture limit
- adjust pointer mapping with presentation scale
- document high-resolution display limitations

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh` *(fails: interrupted after extended compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68a39c2401e08333b8724c8d8aa910ff