### PR TITLE
ui: separate form inputs in creator panels

### DIFF
--- a/src/bin/creator_ui/update.rs
+++ b/src/bin/creator_ui/update.rs
@@ -99,7 +99,7 @@ impl App for CreatorApp {
                     }
                 });
             }
-
+            ui.separator();
             let tree = self.build_dir_tree();
             self.show_dir_node(ui, "", &tree);
         });
@@ -204,6 +204,7 @@ impl App for CreatorApp {
                     self.manifest.assets[idx].license = self.meta[idx].license.clone();
                     let _ = self.save_manifest();
                 }
+                ui.separator();
                 if !meta_snapshot.groups.is_empty() {
                     ui.label("Groups:");
                     for g in &meta_snapshot.groups {


### PR DESCRIPTION
## Summary
- separate asset browser filters from asset list with a separator
- add separator between inspector form inputs and group display

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a3c6e14da0833384a9c55aa558a8d0