### PR TITLE
feat: scrollable asset list in creator UI

### DIFF
--- a/src/bin/creator_ui/update.rs
+++ b/src/bin/creator_ui/update.rs
@@ -100,8 +100,11 @@ impl App for CreatorApp {
                 });
             }
 
+            ui.separator();
             let tree = self.build_dir_tree();
-            self.show_dir_node(ui, "", &tree);
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                self.show_dir_node(ui, "", &tree);
+            });
         });
 
         egui::CentralPanel::default().show(ctx, |ui| {


### PR DESCRIPTION
## Summary
- keep growing asset browser visible by wrapping it in a vertical scroll area
- visually separate filter controls from the asset tree

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a3c6d4ef5483338b311f488ac5deea