### PR TITLE
Downgrade stm32h7 PAC and update platform drivers

### DIFF
--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -29,7 +29,7 @@ heapless = { version = "0.8", default-features = false }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt"] }
 
 [target.'cfg(any(target_arch = "arm", target_os = "none"))'.dependencies]
-stm32h7 = { version = "0.16", optional = true, features = ["stm32h747cm7", "rt"] }
+stm32h7 = { version = "0.15.1", optional = true, features = ["stm32h747cm7", "rt"] }
 stm32h7xx-hal = { version = "0.16", optional = true, features = ["stm32h747cm7", "sdmmc"] }
 cortex-m = { version = "0.7", optional = true, features = ["critical-section-single-core", "cm7"] }
 

--- a/platform/src/otm8009a.rs
+++ b/platform/src/otm8009a.rs
@@ -26,8 +26,8 @@ impl Otm8009a {
     /// Issue a DCS short write command without parameters.
     fn dcs_short_write(dsi: &mut DSIHOST, cmd: u8) {
         // Wait for command FIFO space
-        while dsi.gpsr().read().cmdff().bit_is_set() {}
-        dsi.ghcr().write(|w| unsafe {
+        while dsi.gpsr.read().cmdff().bit_is_set() {}
+        dsi.ghcr.write(|w| unsafe {
             w.dt()
                 .bits(0x05)
                 .vcid()

--- a/platform/src/stm32h747i_disco.rs
+++ b/platform/src/stm32h747i_disco.rs
@@ -70,7 +70,7 @@ impl<B: Blitter, BL, RST> Stm32h747iDiscoDisplay<B, BL, RST> {
         RST: OutputPin,
     {
         // Enable LTDC and DSI peripheral clocks
-        rcc.apb3enr()
+        rcc.apb3enr
             .modify(|_, w| w.ltdcen().set_bit().dsien().set_bit());
         // Ensure the panel is held in reset and the backlight is off
         let _ = reset.set_low();
@@ -112,19 +112,16 @@ impl<B: Blitter, BL, RST> Stm32h747iDiscoDisplay<B, BL, RST> {
         any(target_arch = "arm", target_arch = "aarch64")
     ))]
     fn setup_ltdc_layer(&mut self, fb: u32, width: u16, height: u16) {
-        use stm32h7::stm32h747cm7::ltdc::layer::pfcr::PF;
         let pitch = width * 2; // RGB565
-        let layer0 = self.ltdc.layer(0);
-        layer0.cfbar().write(|w| unsafe { w.cfbadd().bits(fb) });
+        let layer0 = &self.ltdc.layer1;
+        layer0.cfbar.write(|w| w.cfbadd().bits(fb));
         layer0
-            .cfblr()
-            .write(|w| unsafe { w.cfbll().bits(pitch + 3).cfbp().bits(pitch) });
-        layer0
-            .cfblnr()
-            .write(|w| unsafe { w.cfblnbr().bits(height) });
-        layer0.pfcr().write(|w| w.pf().variant(PF::Rgb565));
-        layer0.cr().modify(|_, w| w.len().enabled());
-        self.ltdc.srcr().write(|w| w.imr().reload());
+            .cfblr
+            .write(|w| w.cfbll().bits(pitch + 3).cfbp().bits(pitch));
+        layer0.cfblnr.write(|w| w.cfblnbr().bits(height));
+        layer0.pfcr.write(|w| w.pf().rgb565());
+        layer0.cr.modify(|_, w| w.len().enabled());
+        self.ltdc.srcr.write(|w| w.imr().reload());
     }
 
     #[cfg(all(
@@ -133,7 +130,7 @@ impl<B: Blitter, BL, RST> Stm32h747iDiscoDisplay<B, BL, RST> {
     ))]
     /// Initialize the external SDRAM and return its base address.
     fn init_sdram(_fmc: FMC, rcc: &mut RCC) -> u32 {
-        rcc.ahb3enr().modify(|_, w| w.fmcen().set_bit());
+        rcc.ahb3enr.modify(|_, w| w.fmcen().set_bit());
         0xC000_0000
     }
 }


### PR DESCRIPTION
## Summary
- Downgrade platform's stm32h7 crate to v0.15.1
- Adjust STM32H747I-DISCO display driver for stm32h7 v0.15.1 field API
- Update OTM8009A panel helper to new register accessors

## Testing
- `cargo tree --target thumbv7em-none-eabihf --features stm32h747i_disco | rg stm32h7`
- `cargo build --target thumbv7em-none-eabihf --bin rlvgl-stm32h747i-disco --features stm32h747i_disco` *(fails: cannot find linker script ${RLVGL_LINKER_SCRIPT})*
- `./scripts/pre-commit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a3e70027bc8333b568bc12477f7ebb