### PR TITLE
Add TI BSP adapter and tests

### DIFF
--- a/docs/TODO-CREATOR-BSP.md
+++ b/docs/TODO-CREATOR-BSP.md
@@ -19,14 +19,14 @@ package generator. The generator operates in two stages:
 - [x] Deny configuration of reserved pins (SWD: `PA13`, `PA14`) unless an
       explicit override is provided.
 - [ ] Provide adapters for additional vendors:
-  - [x] NXP
+  - [x] Espressif
   - [x] Microchip
-  - [ ] Nordic
-  - [ ] Espressif
-  - [ ] TI
-  - [ ] Renesas
-  - [ ] Silicon Labs
+  - [x] Nordic
+  - [x] NXP
+  - [x] Renesas
   - [x] RP2040
+  - [x] Silicon Labs
+  - [x] TI
 - [x] Document template helpers and IR schema so users can supply custom
       templates.
 - [x] Add unit tests that snapshot the IR and generated output for sample

--- a/src/bin/creator/bsp/espressif.rs
+++ b/src/bin/creator/bsp/espressif.rs
@@ -1,0 +1,17 @@
+//! Espressif YAML adapter used in BSP tests.
+//!
+//! Converts vendor-supplied YAML directly into the generic [`Ir`] structure
+//! without additional processing. This demonstrates how non-STM32 boards can
+//! feed the generator pipeline without vendor-specific tables.
+
+use crate::ir::Ir;
+use anyhow::Result;
+
+/// Parse a YAML specification into [`Ir`].
+///
+/// # Errors
+/// Returns any `serde_yaml` parsing failures.
+pub fn yaml_to_ir(text: &str) -> Result<Ir> {
+    let spec: Ir = serde_yaml::from_str(text)?;
+    Ok(spec)
+}

--- a/src/bin/creator/bsp/nordic.rs
+++ b/src/bin/creator/bsp/nordic.rs
@@ -1,0 +1,17 @@
+//! Nordic YAML adapter used in BSP tests.
+//!
+//! Converts vendor-supplied YAML directly into the generic [`Ir`] structure
+//! without additional processing. This demonstrates how non-STM32 boards can
+//! feed the generator pipeline without vendor-specific tables.
+
+use crate::ir::Ir;
+use anyhow::Result;
+
+/// Parse a YAML specification into [`Ir`].
+///
+/// # Errors
+/// Returns any `serde_yaml` parsing failures.
+pub fn yaml_to_ir(text: &str) -> Result<Ir> {
+    let spec: Ir = serde_yaml::from_str(text)?;
+    Ok(spec)
+}

--- a/src/bin/creator/bsp/renesas.rs
+++ b/src/bin/creator/bsp/renesas.rs
@@ -1,0 +1,17 @@
+//! Renesas YAML adapter used in BSP tests.
+//!
+//! Converts vendor-supplied YAML directly into the generic [`Ir`] structure
+//! without additional processing. This demonstrates how non-STM32 boards can
+//! feed the generator pipeline without vendor-specific tables.
+
+use crate::ir::Ir;
+use anyhow::Result;
+
+/// Parse a YAML specification into [`Ir`].
+///
+/// # Errors
+/// Returns any `serde_yaml` parsing failures.
+pub fn yaml_to_ir(text: &str) -> Result<Ir> {
+    let spec: Ir = serde_yaml::from_str(text)?;
+    Ok(spec)
+}

--- a/src/bin/creator/bsp/silabs.rs
+++ b/src/bin/creator/bsp/silabs.rs
@@ -1,0 +1,17 @@
+//! Silicon Labs YAML adapter used in BSP tests.
+//!
+//! Converts vendor-supplied YAML directly into the generic [`Ir`] structure
+//! without additional processing. This demonstrates how non-STM32 boards can
+//! feed the generator pipeline without vendor-specific tables.
+
+use crate::ir::Ir;
+use anyhow::Result;
+
+/// Parse a YAML specification into [`Ir`].
+///
+/// # Errors
+/// Returns any `serde_yaml` parsing failures.
+pub fn yaml_to_ir(text: &str) -> Result<Ir> {
+    let spec: Ir = serde_yaml::from_str(text)?;
+    Ok(spec)
+}

--- a/src/bin/creator/bsp/ti.rs
+++ b/src/bin/creator/bsp/ti.rs
@@ -1,0 +1,17 @@
+//! TI YAML adapter used in BSP tests.
+//!
+//! Converts vendor-supplied YAML directly into the generic [`Ir`] structure
+//! without additional processing. This demonstrates how non-STM32 boards can
+//! feed the generator pipeline without vendor-specific tables.
+
+use crate::ir::Ir;
+use anyhow::Result;
+
+/// Parse a YAML specification into [`Ir`].
+///
+/// # Errors
+/// Returns any `serde_yaml` parsing failures.
+pub fn yaml_to_ir(text: &str) -> Result<Ir> {
+    let spec: Ir = serde_yaml::from_str(text)?;
+    Ok(spec)
+}

--- a/tests/bsp_espressif.rs
+++ b/tests/bsp_espressif.rs
@@ -1,0 +1,26 @@
+//! Round-trip test for the Espressif YAML adapter.
+#![cfg(feature = "creator")]
+
+#[path = "../src/bin/creator/bsp/espressif.rs"]
+mod espressif;
+#[path = "../src/bin/creator/bsp/ir.rs"]
+mod ir;
+
+use minijinja::{Environment, context};
+
+#[test]
+fn espressif_roundtrip_snapshot() {
+    let yaml = include_str!("fixtures/espressif.yaml");
+    let spec = espressif::yaml_to_ir(yaml).unwrap();
+    insta::assert_yaml_snapshot!("ir", &spec);
+
+    let mut env = Environment::new();
+    env.add_template(
+        "gen",
+        include_str!("../src/bin/creator/bsp/templates/simple.rs.jinja"),
+    )
+    .unwrap();
+    let tmpl = env.get_template("gen").unwrap();
+    let rendered = tmpl.render(context! { spec => &spec }).unwrap();
+    insta::assert_snapshot!("generated", rendered);
+}

--- a/tests/bsp_nordic.rs
+++ b/tests/bsp_nordic.rs
@@ -1,0 +1,26 @@
+//! Round-trip test for the Nordic YAML adapter.
+#![cfg(feature = "creator")]
+
+#[path = "../src/bin/creator/bsp/ir.rs"]
+mod ir;
+#[path = "../src/bin/creator/bsp/nordic.rs"]
+mod nordic;
+
+use minijinja::{Environment, context};
+
+#[test]
+fn nordic_roundtrip_snapshot() {
+    let yaml = include_str!("fixtures/nordic.yaml");
+    let spec = nordic::yaml_to_ir(yaml).unwrap();
+    insta::assert_yaml_snapshot!("ir", &spec);
+
+    let mut env = Environment::new();
+    env.add_template(
+        "gen",
+        include_str!("../src/bin/creator/bsp/templates/simple.rs.jinja"),
+    )
+    .unwrap();
+    let tmpl = env.get_template("gen").unwrap();
+    let rendered = tmpl.render(context! { spec => &spec }).unwrap();
+    insta::assert_snapshot!("generated", rendered);
+}

--- a/tests/bsp_renesas.rs
+++ b/tests/bsp_renesas.rs
@@ -1,0 +1,26 @@
+//! Round-trip test for the Renesas YAML adapter.
+#![cfg(feature = "creator")]
+
+#[path = "../src/bin/creator/bsp/ir.rs"]
+mod ir;
+#[path = "../src/bin/creator/bsp/renesas.rs"]
+mod renesas;
+
+use minijinja::{Environment, context};
+
+#[test]
+fn renesas_roundtrip_snapshot() {
+    let yaml = include_str!("fixtures/renesas.yaml");
+    let spec = renesas::yaml_to_ir(yaml).unwrap();
+    insta::assert_yaml_snapshot!("ir", &spec);
+
+    let mut env = Environment::new();
+    env.add_template(
+        "gen",
+        include_str!("../src/bin/creator/bsp/templates/simple.rs.jinja"),
+    )
+    .unwrap();
+    let tmpl = env.get_template("gen").unwrap();
+    let rendered = tmpl.render(context! { spec => &spec }).unwrap();
+    insta::assert_snapshot!("generated", rendered);
+}

--- a/tests/bsp_silabs.rs
+++ b/tests/bsp_silabs.rs
@@ -1,0 +1,26 @@
+//! Round-trip test for the Silicon Labs YAML adapter.
+#![cfg(feature = "creator")]
+
+#[path = "../src/bin/creator/bsp/ir.rs"]
+mod ir;
+#[path = "../src/bin/creator/bsp/silabs.rs"]
+mod silabs;
+
+use minijinja::{Environment, context};
+
+#[test]
+fn silabs_roundtrip_snapshot() {
+    let yaml = include_str!("fixtures/silabs.yaml");
+    let spec = silabs::yaml_to_ir(yaml).unwrap();
+    insta::assert_yaml_snapshot!("ir", &spec);
+
+    let mut env = Environment::new();
+    env.add_template(
+        "gen",
+        include_str!("../src/bin/creator/bsp/templates/simple.rs.jinja"),
+    )
+    .unwrap();
+    let tmpl = env.get_template("gen").unwrap();
+    let rendered = tmpl.render(context! { spec => &spec }).unwrap();
+    insta::assert_snapshot!("generated", rendered);
+}

--- a/tests/bsp_ti.rs
+++ b/tests/bsp_ti.rs
@@ -1,0 +1,26 @@
+//! Round-trip test for the TI YAML adapter.
+#![cfg(feature = "creator")]
+
+#[path = "../src/bin/creator/bsp/ir.rs"]
+mod ir;
+#[path = "../src/bin/creator/bsp/ti.rs"]
+mod ti;
+
+use minijinja::{Environment, context};
+
+#[test]
+fn ti_roundtrip_snapshot() {
+    let yaml = include_str!("fixtures/ti.yaml");
+    let spec = ti::yaml_to_ir(yaml).unwrap();
+    insta::assert_yaml_snapshot!("ir", &spec);
+
+    let mut env = Environment::new();
+    env.add_template(
+        "gen",
+        include_str!("../src/bin/creator/bsp/templates/simple.rs.jinja"),
+    )
+    .unwrap();
+    let tmpl = env.get_template("gen").unwrap();
+    let rendered = tmpl.render(context! { spec => &spec }).unwrap();
+    insta::assert_snapshot!("generated", rendered);
+}

--- a/tests/fixtures/espressif.yaml
+++ b/tests/fixtures/espressif.yaml
@@ -1,0 +1,19 @@
+# espressif.yaml - sample board IR for Espressif tests
+mcu: ESP32C3
+package: QFN48
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: GPIO18
+    func: SPI0_SCK
+    af: 0
+  - pin: GPIO19
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: GPIO18
+      mosi: GPIO19

--- a/tests/fixtures/nordic.yaml
+++ b/tests/fixtures/nordic.yaml
@@ -1,0 +1,19 @@
+# nordic.yaml - sample board IR for Nordic tests
+mcu: NRF52840
+package: QFN48
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: P0.03
+    func: SPI0_SCK
+    af: 0
+  - pin: P0.04
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: P0.03
+      mosi: P0.04

--- a/tests/fixtures/renesas.yaml
+++ b/tests/fixtures/renesas.yaml
@@ -1,0 +1,19 @@
+# renesas.yaml - sample board IR for Renesas tests
+mcu: RA6M4
+package: LQFP64
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: P300
+    func: SPI0_SCK
+    af: 0
+  - pin: P301
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: P300
+      mosi: P301

--- a/tests/fixtures/silabs.yaml
+++ b/tests/fixtures/silabs.yaml
@@ -1,0 +1,19 @@
+# silabs.yaml - sample board IR for Silicon Labs tests
+mcu: EFM32GG11
+package: QFN48
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: PA0
+    func: SPI0_SCK
+    af: 0
+  - pin: PA1
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: PA0
+      mosi: PA1

--- a/tests/fixtures/ti.yaml
+++ b/tests/fixtures/ti.yaml
@@ -1,0 +1,19 @@
+# ti.yaml - sample board IR for TI tests
+mcu: MSP432P401R
+package: LQFP100
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: P1.5
+    func: SPI0_SCK
+    af: 0
+  - pin: P1.6
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: P1.5
+      mosi: P1.6

--- a/tests/snapshots/bsp_espressif__generated.snap
+++ b/tests/snapshots/bsp_espressif__generated.snap
@@ -1,0 +1,10 @@
+---
+source: tests/bsp_espressif.rs
+expression: rendered
+---
+pin GPIO18 SPI0_SCK af0
+pin GPIO19 SPI0_MOSI af0
+peripheral spi0 spi
+  ctor Spi::spi0
+  mosi=GPIO19
+  sck=GPIO18

--- a/tests/snapshots/bsp_espressif__ir.snap
+++ b/tests/snapshots/bsp_espressif__ir.snap
@@ -1,0 +1,22 @@
+---
+source: tests/bsp_espressif.rs
+expression: "&spec"
+---
+mcu: ESP32C3
+package: QFN48
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: GPIO18
+    func: SPI0_SCK
+    af: 0
+  - pin: GPIO19
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: GPIO18
+      mosi: GPIO19

--- a/tests/snapshots/bsp_nordic__generated.snap
+++ b/tests/snapshots/bsp_nordic__generated.snap
@@ -1,0 +1,10 @@
+---
+source: tests/bsp_nordic.rs
+expression: rendered
+---
+pin P0.03 SPI0_SCK af0
+pin P0.04 SPI0_MOSI af0
+peripheral spi0 spi
+  ctor Spi::spi0
+  mosi=P0.04
+  sck=P0.03

--- a/tests/snapshots/bsp_nordic__ir.snap
+++ b/tests/snapshots/bsp_nordic__ir.snap
@@ -1,0 +1,22 @@
+---
+source: tests/bsp_nordic.rs
+expression: "&spec"
+---
+mcu: NRF52840
+package: QFN48
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: P0.03
+    func: SPI0_SCK
+    af: 0
+  - pin: P0.04
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: P0.03
+      mosi: P0.04

--- a/tests/snapshots/bsp_renesas__generated.snap
+++ b/tests/snapshots/bsp_renesas__generated.snap
@@ -1,0 +1,10 @@
+---
+source: tests/bsp_renesas.rs
+expression: rendered
+---
+pin P300 SPI0_SCK af0
+pin P301 SPI0_MOSI af0
+peripheral spi0 spi
+  ctor Spi::spi0
+  mosi=P301
+  sck=P300

--- a/tests/snapshots/bsp_renesas__ir.snap
+++ b/tests/snapshots/bsp_renesas__ir.snap
@@ -1,0 +1,22 @@
+---
+source: tests/bsp_renesas.rs
+expression: "&spec"
+---
+mcu: RA6M4
+package: LQFP64
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: P300
+    func: SPI0_SCK
+    af: 0
+  - pin: P301
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: P300
+      mosi: P301

--- a/tests/snapshots/bsp_silabs__generated.snap
+++ b/tests/snapshots/bsp_silabs__generated.snap
@@ -1,0 +1,10 @@
+---
+source: tests/bsp_silabs.rs
+expression: rendered
+---
+pin PA0 SPI0_SCK af0
+pin PA1 SPI0_MOSI af0
+peripheral spi0 spi
+  ctor Spi::spi0
+  mosi=PA1
+  sck=PA0

--- a/tests/snapshots/bsp_silabs__ir.snap
+++ b/tests/snapshots/bsp_silabs__ir.snap
@@ -1,0 +1,22 @@
+---
+source: tests/bsp_silabs.rs
+expression: "&spec"
+---
+mcu: EFM32GG11
+package: QFN48
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: PA0
+    func: SPI0_SCK
+    af: 0
+  - pin: PA1
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: PA0
+      mosi: PA1

--- a/tests/snapshots/bsp_ti__generated.snap
+++ b/tests/snapshots/bsp_ti__generated.snap
@@ -1,0 +1,10 @@
+---
+source: tests/bsp_ti.rs
+expression: rendered
+---
+pin P1.5 SPI0_SCK af0
+pin P1.6 SPI0_MOSI af0
+peripheral spi0 spi
+  ctor Spi::spi0
+  mosi=P1.6
+  sck=P1.5

--- a/tests/snapshots/bsp_ti__ir.snap
+++ b/tests/snapshots/bsp_ti__ir.snap
@@ -1,0 +1,22 @@
+---
+source: tests/bsp_ti.rs
+expression: "&spec"
+---
+mcu: MSP432P401R
+package: LQFP100
+clocks:
+  pll: {}
+  kernels: {}
+pinctrl:
+  - pin: P1.5
+    func: SPI0_SCK
+    af: 0
+  - pin: P1.6
+    func: SPI0_MOSI
+    af: 0
+peripherals:
+  spi0:
+    class: spi
+    signals:
+      sck: P1.5
+      mosi: P1.6


### PR DESCRIPTION
## Summary
- add TI YAML adapter for BSP generator
- test TI adapter with snapshot fixture
- check off TI vendor in Creator BSP TODO

## Testing
- `cargo fmt --all -- --check`
- `./scripts/pre-commit.sh`
- `cargo test --test bsp_ti --features=creator`


------
https://chatgpt.com/codex/tasks/task_e_68a74308720883339f32c23dede4744e