### PR TITLE
Scrape entire STM32 pin data in AFDB pipeline

### DIFF
--- a/scripts/stm32_afdb_pipeline.sh
+++ b/scripts/stm32_afdb_pipeline.sh
@@ -1,26 +1,29 @@
 #!/usr/bin/env bash
-# stm32_afdb_pipeline.sh - Convert STM32 XML and CubeMX IOC to compressed IR.
-# Runs the AFDB pipeline: import MCU XML, build catalog, process IOC,
-# encode and compress catalog to a zstd blob, report size, and clean up.
+# stm32_afdb_pipeline.sh - Package STM32 Open Pin Data into a compressed blob.
+# Scrapes the entire STM32_open_pin_data repository into JSON, bundles it,
+# compresses the archive with zstd, reports the resulting size, and optionally
+# removes temporary files.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
+SCRAPE_OUT="$TMP_DIR/stm32_json"
 LOADER_BIN="$ROOT_DIR/loader.bin.zst"
+KEEP_TEMP=${KEEP_TEMP:-0}
 
 # Ensure submodules are present
- git -C "$ROOT_DIR" submodule update --init --recursive
+git -C "$ROOT_DIR" submodule update --init --recursive
 
-IOC_FILE="$ROOT_DIR/tests/fixtures/simple.ioc"
-MCU_NAME="$(grep -E '^Mcu.Name=' "$IOC_FILE" | cut -d'=' -f2)"
-MCU_XML="$ROOT_DIR/chips/stm/STM32_open_pin_data/mcu/${MCU_NAME}.xml"
+python tools/afdb/stm32_xml_scraper.py --root "$ROOT_DIR/chips/stm/STM32_open_pin_data" --output "$SCRAPE_OUT"
+python tools/afdb/st_extract_af.py --input "$ROOT_DIR/chips/stm/STM32_open_pin_data/boards" --output "$SCRAPE_OUT/boards" --mcu-root "$SCRAPE_OUT/mcu"
 
-python -m tools.afdb.cli import-mcu --in "$MCU_XML" --out "$TMP_DIR/${MCU_NAME}.json"
-python -m tools.afdb.cli build-catalog --mcu "$TMP_DIR/${MCU_NAME}.json" --out "$TMP_DIR/catalog.json"
-python tools/afdb/st_ioc_board.py --ioc "$IOC_FILE" --mcu-root "$TMP_DIR" --board SampleBoard --output "$TMP_DIR/board.json"
-python -m tools.afdb.cli encode-ir --catalog "$TMP_DIR/catalog.json" --out "$LOADER_BIN"
+tar -cf - -C "$SCRAPE_OUT" . | zstd -19 -f -o "$LOADER_BIN"
 
 du -h "$LOADER_BIN"
 
-rm -rf "$TMP_DIR" "$LOADER_BIN"
+if [[ "$KEEP_TEMP" -eq 0 ]]; then
+  rm -rf "$TMP_DIR" "$LOADER_BIN"
+else
+  echo "Keeping temporary files in $TMP_DIR and $LOADER_BIN"
+fi


### PR DESCRIPTION
## Summary
- scan the full STM32_open_pin_data tree and convert board .ioc files to JSON overlays
- auto-detect IP and MCU directories when scraping
- bundle all JSON and compress to a zstd loader archive

## Testing
- `KEEP_TEMP=1 scripts/stm32_afdb_pipeline.sh`
- `scripts/stm32_afdb_pipeline.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa0acf21c88333bb4fa0c7e13407df