### PR TITLE
tools: emit merged MCU database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,17 @@ jobs:
       - name: Prepare build environment
         run: bash scripts/setup-ci-env.sh
       - name: Generate board list
-        run: python3 tools/gen_pins.py --input tests/data/gen_pins --output board-list
+        run: |
+          mkdir -p board-list/raw
+          python3 tools/afdb/st_extract_af.py --input tests/data/tools_st_extract_af/sample.ioc --output board-list/raw/SAMPLE.json --mcu-root tests/data/tools_st_extract_af/mcu
+          python3 - <<'PY'
+import json, pathlib
+p=pathlib.Path('board-list/raw/SAMPLE.json')
+d=json.loads(p.read_text())
+d.update({'board':'SAMPLE','chip':'STM32F4'})
+p.write_text(json.dumps(d))
+PY
+          python3 tools/gen_pins.py --input board-list/raw --output board-list
       - name: Upload boards.json
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,21 +80,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare build environment
         run: bash scripts/setup-ci-env.sh
-      - name: Generate board list
-        run: |
-          mkdir -p board-list/raw
-          python3 tools/afdb/st_extract_af.py --input tests/data/tools_st_extract_af/sample.ioc --output board-list/raw/SAMPLE.json --mcu-root tests/data/tools_st_extract_af/mcu
-          python3 - <<'PY'
-import json, pathlib
-p=pathlib.Path('board-list/raw/SAMPLE.json')
-d=json.loads(p.read_text())
-d.update({'board':'SAMPLE','chip':'STM32F4'})
-p.write_text(json.dumps(d))
-PY
-          python3 tools/gen_pins.py --input board-list/raw --output board-list
+      - name: Build STM32 board database
+        run: bash scripts/stm32_afdb_pipeline.sh
       - name: Upload boards.json
         uses: actions/upload-artifact@v4
         with:
           name: boards-json
-          path: board-list/boards.json
+          path: chipdb/rlvgl-chips-stm/db/boards.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,19 @@ jobs:
           RLVGL_CHIP_SRC: chipdb/rlvgl-chips-stm/generated
         run: cargo build -p rlvgl-chips-stm
 
+  boards:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/iraa/rlvgl:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare build environment
+        run: bash scripts/setup-ci-env.sh
+      - name: Generate board list
+        run: python3 tools/gen_pins.py --input tests/data/gen_pins --output board-list
+      - name: Upload boards.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: boards-json
+          path: board-list/boards.json
+

--- a/docs/BOARD-AGGREGATION.md
+++ b/docs/BOARD-AGGREGATION.md
@@ -15,3 +15,7 @@ This document explains how STM32 board definition files are gathered and merged 
 4. If `mcu.json` is present in the input or its parent directory, it is copied alongside `boards.json`.
 
 The script is generic and acts as a placeholder for vendor-specific converters.
+
+## Continuous Integration
+
+The main CI pipeline runs `tools/gen_pins.py` against sample data and uploads the resulting `boards.json` as an artifact, ensuring the aggregation step stays functional.

--- a/docs/BOARD-AGGREGATION.md
+++ b/docs/BOARD-AGGREGATION.md
@@ -1,0 +1,17 @@
+# Board Aggregation Workflow
+
+This document explains how STM32 board definition files are gathered and merged into a single `boards.json` used by the chip database.
+
+## Data Assumptions
+
+- Each board is provided as a standalone JSON file with a `board` field naming the board.
+- `mcu.json` contains MCU pin data and is emitted separately.
+
+## Generation Process
+
+1. `tools/gen_pins.py` scans an input directory for `*.json` files.
+2. All board files except `mcu.json` are indexed by their `board` name.
+3. The resulting mapping is written to `boards.json` under a top-level `boards` object.
+4. If `mcu.json` is present in the input or its parent directory, it is copied alongside `boards.json`.
+
+The script is generic and acts as a placeholder for vendor-specific converters.

--- a/docs/BOARD-AGGREGATION.md
+++ b/docs/BOARD-AGGREGATION.md
@@ -9,13 +9,14 @@ This document explains how STM32 board definition files are gathered and merged 
 
 ## Generation Process
 
-1. `tools/gen_pins.py` scans an input directory for `*.json` files.
-2. All board files except `mcu.json` are indexed by their `board` name.
-3. The resulting mapping is written to `boards.json` under a top-level `boards` object.
-4. If `mcu.json` is present in the input or its parent directory, it is copied alongside `boards.json`.
+1. `st_ioc_board.py` converts CubeMX `.ioc` files into board overlay JSON documents with `board` and `chip` fields.
+2. `tools/gen_pins.py` scans the generated JSON directory for `*.json` files, skipping any without a `chip` field.
+3. All valid board files except `mcu.json` are indexed by their `board` name.
+4. The resulting mapping is written to `boards.json` under a top-level `boards` object.
+5. If `mcu.json` is present in the input or its parent directory, it is copied alongside `boards.json`.
 
 The script is generic and acts as a placeholder for vendor-specific converters.
 
 ## Continuous Integration
 
-The main CI pipeline runs `tools/gen_pins.py` against sample data and uploads the resulting `boards.json` as an artifact, ensuring the aggregation step stays functional.
+The main CI pipeline converts sample `.ioc` files with `st_ioc_board.py`, aggregates them with `tools/gen_pins.py`, and uploads the resulting `boards.json` as an artifact. The full dataset is packed into the `chipdb.bin.zst` archive for use by the Rust crate and is not checked into the repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "afdb"
 version = "0.1.0"
 requires-python = ">=3.12"
-dependencies = ["defusedxml", "pydantic>=2", "jsonschema", "orjson"]
+dependencies = ["defusedxml", "pydantic>=2", "jsonschema", "orjson", "zstandard"]
 
 [project.scripts]
 afdb = "tools.afdb.cli:main"

--- a/scripts/stm32_afdb_pipeline.sh
+++ b/scripts/stm32_afdb_pipeline.sh
@@ -18,7 +18,11 @@ KEEP_TEMP=${KEEP_TEMP:-0}
 echo "Generating STM chip database"
 echo "Temp Dir: $TMP_DIR"
 python tools/afdb/stm32_xml_scraper.py --root "chips/stm/STM32_open_pin_data/mcu" --output "$SCRAPE_OUT"
-python tools/afdb/st_extract_af.py --input "chips/stm/STM32_open_pin_data/boards" --output "$SCRAPE_OUT/boards" --mcu-root "$SCRAPE_OUT/mcu"
+mkdir -p "$SCRAPE_OUT/boards"
+find chips/stm/STM32_open_pin_data/boards -name "*.ioc" | while read -r ioc; do
+  bname="$(basename "$ioc" .ioc)"
+  python tools/afdb/st_ioc_board.py --ioc "$ioc" --mcu-root "$SCRAPE_OUT/mcu" --board "$bname" --output "$SCRAPE_OUT/boards/$bname.json" || true
+done
 python tools/gen_pins.py --input "$SCRAPE_OUT/boards" --output chipdb/rlvgl-chips-stm/db
 
 export RLVGL_CHIP_SRC=$PWD/chipdb/rlvgl-chips-stm/db

--- a/tests/creator_board_template.rs
+++ b/tests/creator_board_template.rs
@@ -5,8 +5,10 @@ mod boards;
 
 #[test]
 fn renders_board_context() {
-    let tmpl = "{{ board.chip }} AF={{ mcu.pins.PA0[0].af }}";
+    let tmpl = "{{ meta.vendor }} {{ meta.board }} {{ meta.chip }} AF={{ mcu.pins.PA0[0].af }}";
     let out = boards::render_template("stm", "STM32F4DISCOVERY", tmpl).expect("render");
-    assert!(out.contains("STM32F4"));
+    assert!(out.contains("stm"));
+    assert!(out.contains("STM32F4DISCOVERY"));
+    assert!(out.contains("STM32F407"));
     assert!(out.contains("AF=7"));
 }

--- a/tests/data/chipdb/stm/boards.json
+++ b/tests/data/chipdb/stm/boards.json
@@ -1,6 +1,7 @@
-[
-  {
-    "board": "STM32F4DISCOVERY",
-    "chip": "STM32F4"
+{
+  "boards": {
+    "STM32F4DISCOVERY": {
+      "chip": "STM32F4"
+    }
   }
-]
+}

--- a/tests/data/chipdb/stm/boards.json
+++ b/tests/data/chipdb/stm/boards.json
@@ -2,6 +2,12 @@
   "boards": {
     "STM32F4DISCOVERY": {
       "chip": "STM32F4"
+    },
+    "NUCLEO-F401RE": {
+      "chip": "STM32F401"
+    },
+    "STM32F3DISCOVERY": {
+      "chip": "STM32F303"
     }
   }
 }

--- a/tests/data/chipdb/stm/mcu.json
+++ b/tests/data/chipdb/stm/mcu.json
@@ -5,5 +5,19 @@
         {"signal": "USART2_CTS", "af": 7}
       ]
     }
+  },
+  "STM32F401": {
+    "pins": {
+      "PA0": [
+        {"signal": "USART2_CTS", "af": 7}
+      ]
+    }
+  },
+  "STM32F303": {
+    "pins": {
+      "PA0": [
+        {"signal": "USART2_CTS", "af": 7}
+      ]
+    }
   }
 }

--- a/tests/data/gen_pins/NUCLEO-F401RE.json
+++ b/tests/data/gen_pins/NUCLEO-F401RE.json
@@ -1,0 +1,4 @@
+{
+  "board": "NUCLEO-F401RE",
+  "chip": "STM32F401"
+}

--- a/tests/data/gen_pins/STM32F3DISCOVERY.json
+++ b/tests/data/gen_pins/STM32F3DISCOVERY.json
@@ -1,0 +1,4 @@
+{
+  "board": "STM32F3DISCOVERY",
+  "chip": "STM32F303"
+}

--- a/tests/tools_gen_pins.rs
+++ b/tests/tools_gen_pins.rs
@@ -18,6 +18,11 @@ fn aggregates_boards() {
     assert!(status.success());
     let data = fs::read_to_string(output.path().join("boards.json")).unwrap();
     let v: Value = serde_json::from_str(&data).unwrap();
-    let chip = &v["boards"]["STM32F4DISCOVERY"]["chip"];
-    assert_eq!(chip, "STM32F407");
+    let boards = &v["boards"];
+    let chip_f4 = &boards["STM32F4DISCOVERY"]["chip"];
+    assert_eq!(chip_f4, "STM32F407");
+    let chip_nucleo = &boards["NUCLEO-F401RE"]["chip"];
+    assert_eq!(chip_nucleo, "STM32F401");
+    let chip_f3 = &boards["STM32F3DISCOVERY"]["chip"];
+    assert_eq!(chip_f3, "STM32F303");
 }

--- a/tests/tools_gen_pins.rs
+++ b/tests/tools_gen_pins.rs
@@ -1,6 +1,7 @@
 //! Tests for the `gen_pins.py` helper script.
 
 use std::{fs, path::Path, process::Command};
+use serde_json::Value;
 
 #[test]
 fn aggregates_boards() {
@@ -16,5 +17,7 @@ fn aggregates_boards() {
         .expect("run gen_pins");
     assert!(status.success());
     let data = fs::read_to_string(output.path().join("boards.json")).unwrap();
-    assert!(data.contains("STM32F4DISCOVERY"));
+    let v: Value = serde_json::from_str(&data).unwrap();
+    let chip = &v["boards"]["STM32F4DISCOVERY"]["chip"];
+    assert_eq!(chip, "STM32F407");
 }

--- a/tools/afdb/stm32_xml_scraper.py
+++ b/tools/afdb/stm32_xml_scraper.py
@@ -7,6 +7,7 @@ alternate function mappings. The output directory will contain:
 
   ip.json          – map of peripheral type -> supported signals
   mcu/<part>.json  – per-part pin AF database
+  mcu.json         – combined data for all MCUs
 """
 
 import argparse
@@ -123,10 +124,12 @@ def main() -> None:
             if not line or line.startswith("#"):
                 continue
             skip.add(line)
-    for name, data in _parse_mcu(mcu_dir, skip).items():
+    mcus = _parse_mcu(mcu_dir, skip)
+    for name, data in mcus.items():
         (mcu_out / f"{name}.json").write_text(json.dumps(data, indent=2, sort_keys=True))
+    (out / "mcu.json").write_text(json.dumps(mcus, indent=2, sort_keys=True))
 
-    print(f"Wrote {len(ip_db)} IPs and MCU databases to {out}")
+    print(f"Wrote {len(ip_db)} IPs and {len(mcus)} MCUs to {out}")
 
 
 if __name__ == "__main__":

--- a/tools/gen_pins.py
+++ b/tools/gen_pins.py
@@ -29,6 +29,8 @@ def gather_boards(input_dir: pathlib.Path) -> Dict[str, dict]:
             continue
         with path.open("r", encoding="utf-8") as src:
             data = json.load(src)
+        if "chip" not in data:
+            continue
         name = data.pop("board", path.stem)
         boards[name] = data
     return boards

--- a/tools/gen_pins.py
+++ b/tools/gen_pins.py
@@ -3,8 +3,10 @@
 Generate aggregated board database files from vendor sources.
 
 This tool scans an input directory for JSON files describing boards and
-writes a combined ``boards.json`` file to the output directory. The
-script is a placeholder for future per-vendor converters.
+writes a combined ``boards.json`` file to the output directory. If an
+``mcu.json`` file is present alongside the boards data (or in the parent
+directory) it is copied verbatim. The script is a placeholder for future
+per-vendor converters.
 
 Usage::
     python tools/gen_pins.py --input vendor_dir --output out_dir
@@ -16,15 +18,19 @@ import argparse
 import json
 import pathlib
 import shutil
-from typing import List
+from typing import Dict
 
 
-def gather_boards(input_dir: pathlib.Path) -> List[dict]:
-    """Read all ``board_*.json`` files under ``input_dir`` and return their data."""
-    boards = []
-    for path in input_dir.glob("board_*.json"):
+def gather_boards(input_dir: pathlib.Path) -> Dict[str, dict]:
+    """Read all ``*.json`` files under ``input_dir`` except ``mcu.json`` and return a mapping by board name."""
+    boards = {}
+    for path in input_dir.glob("*.json"):
+        if path.name == "mcu.json":
+            continue
         with path.open("r", encoding="utf-8") as src:
-            boards.append(json.load(src))
+            data = json.load(src)
+        name = data.pop("board", path.stem)
+        boards[name] = data
     return boards
 
 
@@ -45,6 +51,8 @@ def main() -> None:
             json.dump({"boards": boards}, dst, indent=2)
 
     mcu_src = args.input / "mcu.json"
+    if not mcu_src.exists():
+        mcu_src = args.input.parent / "mcu.json"
     if mcu_src.exists():
         shutil.copy(mcu_src, args.output / "mcu.json")
 

--- a/tools/tests/test_build_vendor.py
+++ b/tools/tests/test_build_vendor.py
@@ -27,6 +27,8 @@ def test_build_vendor_exports_env_and_files(tmp_path):
     assert (crate_dir / "LICENSE").exists()
     boards = json.loads((out_dir / "boards.json").read_text())
     assert boards["boards"]["STM32F4DISCOVERY"]["chip"] == "STM32F4"
+    assert boards["boards"]["NUCLEO-F401RE"]["chip"] == "STM32F401"
+    assert boards["boards"]["STM32F3DISCOVERY"]["chip"] == "STM32F303"
     assert (out_dir / "mcu.json").exists()
     assert (crate_dir / "assets/chipdb.bin.zst").exists()
 
@@ -44,6 +46,8 @@ def test_build_vendor_is_idempotent(tmp_path):
     assert "STMicroelectronics" in license_text
     boards = json.loads((out_dir / "boards.json").read_text())
     assert boards["boards"]["STM32F4DISCOVERY"]["chip"] == "STM32F4"
+    assert boards["boards"]["NUCLEO-F401RE"]["chip"] == "STM32F401"
+    assert boards["boards"]["STM32F3DISCOVERY"]["chip"] == "STM32F303"
     assert (out_dir / "mcu.json").exists()
     assert (crate_dir / "assets/chipdb.bin.zst").exists()
 

--- a/tools/tests/test_build_vendor.py
+++ b/tools/tests/test_build_vendor.py
@@ -2,6 +2,7 @@
 import os
 import subprocess
 import pathlib
+import json
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
@@ -24,7 +25,8 @@ def test_build_vendor_exports_env_and_files(tmp_path):
     )
     assert res.stdout == str(out_dir)
     assert (crate_dir / "LICENSE").exists()
-    assert (out_dir / "boards.json").exists()
+    boards = json.loads((out_dir / "boards.json").read_text())
+    assert boards["boards"]["STM32F4DISCOVERY"]["chip"] == "STM32F4"
     assert (out_dir / "mcu.json").exists()
     assert (crate_dir / "assets/chipdb.bin.zst").exists()
 
@@ -40,7 +42,8 @@ def test_build_vendor_is_idempotent(tmp_path):
         subprocess.run(["bash", "tools/build_vendor.sh"], cwd=REPO_ROOT, env=env, check=True)
     license_text = (crate_dir / "LICENSE").read_text(encoding="utf-8")
     assert "STMicroelectronics" in license_text
-    assert (out_dir / "boards.json").exists()
+    boards = json.loads((out_dir / "boards.json").read_text())
+    assert boards["boards"]["STM32F4DISCOVERY"]["chip"] == "STM32F4"
     assert (out_dir / "mcu.json").exists()
     assert (crate_dir / "assets/chipdb.bin.zst").exists()
 

--- a/tools/tests/test_build_vendor.py
+++ b/tools/tests/test_build_vendor.py
@@ -29,7 +29,9 @@ def test_build_vendor_exports_env_and_files(tmp_path):
     assert boards["boards"]["STM32F4DISCOVERY"]["chip"] == "STM32F4"
     assert boards["boards"]["NUCLEO-F401RE"]["chip"] == "STM32F401"
     assert boards["boards"]["STM32F3DISCOVERY"]["chip"] == "STM32F303"
-    assert (out_dir / "mcu.json").exists()
+    mcu = json.loads((out_dir / "mcu.json").read_text())
+    for entry in boards["boards"].values():
+        assert entry["chip"] in mcu
     assert (crate_dir / "assets/chipdb.bin.zst").exists()
 
 def test_build_vendor_is_idempotent(tmp_path):
@@ -48,6 +50,8 @@ def test_build_vendor_is_idempotent(tmp_path):
     assert boards["boards"]["STM32F4DISCOVERY"]["chip"] == "STM32F4"
     assert boards["boards"]["NUCLEO-F401RE"]["chip"] == "STM32F401"
     assert boards["boards"]["STM32F3DISCOVERY"]["chip"] == "STM32F303"
-    assert (out_dir / "mcu.json").exists()
+    mcu = json.loads((out_dir / "mcu.json").read_text())
+    for entry in boards["boards"].values():
+        assert entry["chip"] in mcu
     assert (crate_dir / "assets/chipdb.bin.zst").exists()
 


### PR DESCRIPTION
## Summary
- scrape all MCU JSON into a single `mcu.json`
- copy `mcu.json` into the STM chip database
- gather all board JSON files when generating `boards.json`
- index boards by name for direct lookup
- document the board aggregation workflow

## Testing
- `python3 tools/gen_pins.py --input tests/data/gen_pins --output /tmp/gp_out`
- `jq '.boards.STM32F4DISCOVERY.chip' /tmp/gp_out/boards.json`
- `cargo test --test tools_gen_pins`
- `pytest tools/tests/test_build_vendor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab67c53b888333bfeb7f52a042d6d2