### PR TITLE
fix: correct interrupt masking list

### DIFF
--- a/examples/stm32h747i-disco/bsp/hal.rs
+++ b/examples/stm32h747i-disco/bsp/hal.rs
@@ -1506,63 +1506,12 @@ pub fn deinit_board_hal(dp: &pac::Peripherals) {
     // Disable DMA controllers and mask their interrupts
 
     // Disable interrupts
-    unsafe { pac::NVIC::mask(pac::Interrupt::[); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::I); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::2); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::C); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::4); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::_); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::E); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::V); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::,); }
-    unsafe { pac::NVIC::mask(pac::Interrupt:: ); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::I); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::2); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::C); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::4); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::_); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::E); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::R); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::]); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::[); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::S); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::P); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::I); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::2); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::]); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::[); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::S); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::P); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::I); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::5); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::]); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::[); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::U); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::A); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::R); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::T); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::8); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::]); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::[); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::U); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::S); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::A); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::R); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::T); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::1); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::"); }
-    unsafe { pac::NVIC::mask(pac::Interrupt::]); }
+    unsafe { pac::NVIC::mask(pac::Interrupt::I2C4_EV); }
+    unsafe { pac::NVIC::mask(pac::Interrupt::I2C4_ER); }
+    unsafe { pac::NVIC::mask(pac::Interrupt::SPI2); }
+    unsafe { pac::NVIC::mask(pac::Interrupt::SPI5); }
+    unsafe { pac::NVIC::mask(pac::Interrupt::UART8); }
+    unsafe { pac::NVIC::mask(pac::Interrupt::USART1); }
 }
 
 

--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -241,20 +241,18 @@ pub fn deinit_board_hal(dp: &pac::Peripherals) {
     {%- endif %}
 
     // Disable interrupts
-{%- macro irq_list(name) -%}
-{%- if name == "i2c4" -%}["I2C4_EV", "I2C4_ER"]
-{%- elif name == "spi2" -%}["SPI2"]
-{%- elif name == "spi5" -%}["SPI5"]
-{%- elif name == "uart8" -%}["UART8"]
-{%- elif name == "usart1" -%}["USART1"]
-{%- else -%}[]
-{%- endif -%}
-{%- endmacro %}
-{%- for name, _per in spec.peripherals | dictsort %}
-    {%- for irq in irq_list(name) %}
+    {%- set irq_map = {
+        "i2c4": ["I2C4_EV", "I2C4_ER"],
+        "spi2": ["SPI2"],
+        "spi5": ["SPI5"],
+        "uart8": ["UART8"],
+        "usart1": ["USART1"],
+    } -%}
+    {%- for name, _per in spec.peripherals | dictsort %}
+        {%- for irq in irq_map.get(name, []) %}
     unsafe { pac::NVIC::mask(pac::Interrupt::{{ irq }}); }
+        {%- endfor %}
     {%- endfor %}
-{%- endfor %}
 }
 {% endif %}
 


### PR DESCRIPTION
## Summary
- fix interrupt masking template to use list instead of char iteration
- update stm32h747i-disco HAL example to show correct interrupt names

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68acb33177c48333bab70fcac4e54da9