### PR TITLE
Fix load_ir to return board and MCU info

### DIFF
--- a/chips/stm/bsps/src/lib.rs
+++ b/chips/stm/bsps/src/lib.rs
@@ -27,11 +27,14 @@ pub struct BoardInfo {
 
 pub mod f407_demo;
 pub mod f429_demo;
+pub mod stm32f4discovery;
 use f407_demo::INFO as F407_DEMO;
 use f429_demo::INFO as F429_DEMO;
+use stm32f4discovery::INFO as STM32F4DISCOVERY;
 const BOARDS: &[BoardInfo] = &[
     F407_DEMO,
     F429_DEMO,
+    STM32F4DISCOVERY,
 ];
 
 /// Returns the vendor identifier.

--- a/chips/stm/bsps/src/stm32f4discovery.rs
+++ b/chips/stm/bsps/src/stm32f4discovery.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+//! BSP module for the STM32F4DISCOVERY board.
+
+use crate::{BoardInfo, PinInfo};
+
+/// Pin assignments for STM32F4DISCOVERY.
+pub const PINS: &[PinInfo] = &[
+    PinInfo { pin: "PA0", signal: "USART2_TX" },
+    PinInfo { pin: "PA1", signal: "USART2_RX" },
+];
+
+/// Board info for STM32F4DISCOVERY.
+pub const INFO: BoardInfo = BoardInfo {
+    board: "STM32F4DISCOVERY",
+    chip: "STM32F407",
+    pins: PINS,
+};

--- a/src/bin/creator/boards.rs
+++ b/src/bin/creator/boards.rs
@@ -21,6 +21,44 @@ use std::io::Read;
 use zstd::stream::read::Decoder;
 use minijinja::{Environment, context};
 use serde::Serialize;
+#[cfg(test)]
+mod test_vendor {
+    use std::sync::OnceLock;
+
+    pub fn vendor() -> &'static str {
+        "test"
+    }
+
+    pub fn raw_db() -> &'static [u8] {
+        static DATA: OnceLock<Vec<u8>> = OnceLock::new();
+        DATA.get_or_init(|| {
+            let txt = concat!(
+                ">boards/demo.json\n",
+                "{\"board\":\"demo\",\"chip\":\"STM32F4\",\"pins\":{\"PA0\":{\"USART2_TX\":7}}}\n",
+                "<\n",
+                ">mcu.json\n",
+                "{\"STM32F4\":{\"pins\":{\"PA0\":[{\"instance\":\"USART2\",\"signal\":\"USART2_TX\",\"af\":7}]}}}\n",
+                "<\n",
+            );
+            zstd::stream::encode_all(txt.as_bytes(), 0).expect("zstd")
+        })
+        .as_slice()
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct BoardInfo {
+        pub board: &'static str,
+        pub chip: &'static str,
+    }
+
+    pub fn boards() -> &'static [BoardInfo] {
+        &[BoardInfo { board: "demo", chip: "STM32F4" }]
+    }
+
+    pub fn find(board: &str) -> Option<BoardInfo> {
+        boards().iter().find(|b| b.board == board).copied()
+    }
+}
 
 /// Combined vendor and board information.
 #[derive(Serialize)]
@@ -132,6 +170,8 @@ pub fn find_board(vendor: &str, board: &str) -> Result<VendorBoard, String> {
     check_vendor!(renesas);
     check_vendor!(ti);
     check_vendor!(rp2040);
+    #[cfg(test)]
+    check_vendor!(test_vendor);
     Err(format!("Unknown vendor '{}'", vendor))
 }
 
@@ -176,28 +216,37 @@ pub fn load_ir(vendor: &str, board: &str) -> Result<(Value, Value), String> {
         v if v == renesas::vendor() => renesas::raw_db(),
         v if v == ti::vendor() => ti::raw_db(),
         v if v == rp2040::vendor() => rp2040::raw_db(),
+        #[cfg(test)]
+        v if v == test_vendor::vendor() => test_vendor::raw_db(),
         _ => return Err(format!("Unknown vendor '{}'", vendor)),
     };
     let files = parse_raw_db(blob);
+    let board_key = format!("boards/{}.json", board);
+    let board_json = files
+        .get(&board_key)
+        .ok_or_else(|| format!("{} missing from vendor archive", board_key))?;
+    let board_val: Value =
+        serde_json::from_slice(board_json).map_err(|e| format!("parse {board_key}: {e}"))?;
     let mcu_json = files
         .get("mcu.json")
         .ok_or("mcu.json missing from vendor archive")?;
     let mcu_map: HashMap<String, Value> =
         serde_json::from_slice(mcu_json).map_err(|e| format!("parse mcu.json: {e}"))?;
-    mcu_map
+    let mcu_val = mcu_map
         .get(info.chip)
         .cloned()
-        .ok_or_else(|| format!("MCU '{}' not in archive", info.chip))
+        .ok_or_else(|| format!("MCU '{}' not in archive", info.chip))?;
+    Ok((board_val, mcu_val))
 }
 
 /// Render a MiniJinja `template` using MCU context.
 #[must_use]
 pub fn render_template(vendor: &str, board: &str, template: &str) -> Result<String, String> {
-    let mcu_val = load_ir(vendor, board)?;
+    let (board_val, mcu_val) = load_ir(vendor, board)?;
     let info = find_board(vendor, board)?;
     let mut env = Environment::new();
     env.add_template("user", template).map_err(|e| e.to_string())?;
-    let ctx = context! { mcu => mcu_val, meta => info };
+    let ctx = context! { board => board_val, mcu => mcu_val, meta => info };
     env.get_template("user")
         .and_then(|t| t.render(ctx))
         .map_err(|e| e.to_string())

--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -4,6 +4,9 @@
  * SPDX-FileCopyrightText: 2025 Softoboros Technology, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  * Provenance: STM32_open_pin_data (commit <hash>), build <build-hash>.
+{% if meta is defined %}
+ * Board: {{ meta.board }} ({{ meta.chip }})
+{% endif %}
  */
 #![allow(non_snake_case)]
 #![allow(clippy::too_many_arguments)]

--- a/src/bin/creator/bsp/templates/pac.rs.jinja
+++ b/src/bin/creator/bsp/templates/pac.rs.jinja
@@ -4,6 +4,9 @@
  * SPDX-FileCopyrightText: 2025 Softoboros Technology, Inc.
  * SPDX-License-Identifier: BSD-3-Clause
  * Provenance: STM32_open_pin_data (commit <hash>), build <build-hash>.
+{% if meta is defined %}
+ * Board: {{ meta.board }} ({{ meta.chip }})
+{% endif %}
  */
 #![allow(non_snake_case)]
 #![allow(clippy::too_many_arguments)]

--- a/src/bin/creator/bsp/templates/simple.rs.jinja
+++ b/src/bin/creator/bsp/templates/simple.rs.jinja
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * Provenance: STM32_open_pin_data (commit <hash>), build <build-hash>.
  */
+{% if meta is defined %}
+board {{ meta.vendor }} {{ meta.board }} {{ meta.chip }}
+{% endif %}
 {%- for name, pll in spec.clocks.pll | dictsort %}
 pll {{ name }} m{{ pll.m }} n{{ pll.n }} p{{ pll.p }} q{{ pll.q }} r{{ pll.r }}
 {%- endfor %}

--- a/src/bin/creator_ui/commands.rs
+++ b/src/bin/creator_ui/commands.rs
@@ -1,7 +1,7 @@
 //! Command handlers and dialogs for rlgvl-creator UI.
 
 use super::presets::{CommandPreset, run_preset_commands};
-use super::wizard::{WizardStep, run_scan_convert_preview_wizard};
+use super::wizard::run_scan_convert_preview_wizard;
 use super::*;
 
 impl CreatorApp {

--- a/src/bin/creator_ui/mod.rs
+++ b/src/bin/creator_ui/mod.rs
@@ -35,6 +35,7 @@ mod init;
 #[path = "../creator/lottie.rs"]
 mod lottie;
 #[path = "../creator/manifest.rs"]
+#[allow(dead_code)]
 mod manifest;
 #[path = "../creator/preview.rs"]
 mod preview;
@@ -49,11 +50,13 @@ mod svg;
 #[path = "../creator/sync.rs"]
 mod sync;
 #[path = "../creator/util.rs"]
+#[allow(dead_code)]
 mod util;
 #[path = "../creator/vendor.rs"]
 mod vendor;
 
 #[path = "../creator/boards.rs"]
+#[allow(dead_code)]
 pub mod boards;
 
 mod board_select;

--- a/tests/creator_board_overlay.rs
+++ b/tests/creator_board_overlay.rs
@@ -1,0 +1,21 @@
+#![cfg(feature = "creator")]
+//! Verify board overlay loading and metadata access within templates.
+
+#[path = "../src/bin/creator/boards.rs"]
+mod boards;
+
+#[test]
+fn load_ir_and_render_template_expose_board_meta() {
+    let (board, mcu) = boards::load_ir("test", "demo").expect("load");
+    assert_eq!(board["board"], "demo");
+    assert_eq!(board["chip"], "STM32F4");
+    assert!(mcu["pins"]["PA0"].is_array());
+
+    let out = boards::render_template(
+        "test",
+        "demo",
+        "{{ meta.board }} {{ meta.chip }} {{ board.chip }} {{ mcu.pins.PA0[0].instance }}",
+    )
+    .expect("render");
+    assert!(out.contains("demo STM32F4 STM32F4 USART2"));
+}


### PR DESCRIPTION
## Summary
- suppress dead code warnings in creator UI by marking reused modules
- expose board metadata in BSP templates when available
- add STM32F4DISCOVERY BSP stub and test verifying board overlay loading

## Testing
- `cargo run --bin rlvgl-creator --features creator,creator_ui`
- `cargo test --features creator --test creator_board_overlay`


------
https://chatgpt.com/codex/tasks/task_e_68acbc67848483339c17204a155aa8c3