### PR TITLE
creator: add allow-reserved option to BSP command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,3 +10,4 @@ CHANGELOG.md - Notes on chip & board database releases.
 - Introduced `st_ioc_board.py` to convert CubeMX `.ioc` files into board overlays.
 - `rlvgl-creator` can now load canonical MCU definitions alongside board overlays from vendor archives.
 - Added `rlvgl-creator board from-ioc` to convert user CubeMX projects into board overlays.
+- Added `--allow-reserved` flag to `rlvgl-creator bsp from-ioc` to permit SWD pins `PA13`/`PA14`.

--- a/docs/CREATOR-CLI.md
+++ b/docs/CREATOR-CLI.md
@@ -179,6 +179,7 @@ Renders Rust source from a CubeMX project using a MiniJinja template.
 ```
 rlvgl-creator bsp from-ioc <ioc> <af> [--emit-hal] [--emit-pac] [--template <template>]
     --out <dir> [--grouped-writes] [--one-file | --per-peripheral] [--with-deinit]
+    [--allow-reserved]
 ```
 * `ioc` – input CubeMX `.ioc` file.
 * `af` – JSON alternate-function database.
@@ -192,6 +193,7 @@ rlvgl-creator bsp from-ioc <ioc> <af> [--emit-hal] [--emit-pac] [--template <tem
 * `--one-file` – emit a single consolidated source file.
 * `--per-peripheral` – emit one file per peripheral with feature gating.
 * `--with-deinit` – include optional de-initialization helpers.
+* `--allow-reserved` – permit configuration of reserved SWD pins (`PA13`, `PA14`).
   Helpers gate clocks, mask IRQs, and reset DMA/BDMA/MDMA configuration
   registers, including DMAMUX routing and stream/channel edge cases.
   Covers controllers across F0, F1, F2, F3, F4, F7, H5, H7, L0, L1, L4,

--- a/scripts/gen_ioc_bsps.sh
+++ b/scripts/gen_ioc_bsps.sh
@@ -40,7 +40,7 @@ find "$BOARD_DIR" -name '*.ioc' | while read -r ioc; do
       layout_flag="--per-peripheral"
     fi
     "$RLVGL_CREATOR" bsp from-ioc "$ioc" "$AF_JSON" \
-      --emit-hal --emit-pac --grouped-writes --with-deinit $layout_flag \
+      --emit-hal --emit-pac --grouped-writes --with-deinit --allow-reserved $layout_flag \
       --out "$out_dir" || echo "failed: $board ($layout)"
   done
 done

--- a/src/bin/creator/bsp_gen.rs
+++ b/src/bin/creator/bsp_gen.rs
@@ -42,11 +42,12 @@ pub(crate) fn from_ioc(
     out_dir: &Path,
     grouped_writes: bool,
     with_deinit: bool,
+    allow_reserved: bool,
     layout: Layout,
 ) -> Result<()> {
     let text = fs::read_to_string(ioc_path)?;
     let af = JsonAfDb::from_path(af_json)?;
-    let ir = ioc::ioc_to_ir(&text, &af, false)?;
+    let ir = ioc::ioc_to_ir(&text, &af, allow_reserved)?;
 
     // Ensure all peripherals reference known pins
     use std::collections::HashSet;

--- a/src/bin/creator/cli.rs
+++ b/src/bin/creator/cli.rs
@@ -281,6 +281,9 @@ enum BspCommand {
         /// Include optional de-initialization helpers
         #[arg(long)]
         with_deinit: bool,
+        /// Permit configuration of reserved SWD pins (PA13/PA14)
+        #[arg(long)]
+        allow_reserved: bool,
     },
 }
 
@@ -369,24 +372,26 @@ pub fn run() -> Result<()> {
                         &dir,
                         false,
                         false,
+                        false,
                         bsp_gen::Layout::OneFile,
                     )?;
                 }
             }
         },
         Command::Bsp { cmd } => match cmd {
-            BspCommand::FromIoc {
-                ioc,
-                af,
-                out,
-                emit_hal,
-                emit_pac,
-                template,
-                grouped_writes,
-                one_file: _,
-                per_peripheral,
-                with_deinit,
-            } => {
+        BspCommand::FromIoc {
+            ioc,
+            af,
+            out,
+            emit_hal,
+            emit_pac,
+            template,
+            grouped_writes,
+            one_file: _,
+            per_peripheral,
+            with_deinit,
+            allow_reserved,
+        } => {
                 let mut kinds = Vec::new();
                 if emit_hal {
                     kinds.push(bsp_gen::TemplateKind::Hal);
@@ -413,6 +418,7 @@ pub fn run() -> Result<()> {
                         &out,
                         grouped_writes,
                         with_deinit,
+                        allow_reserved,
                         layout.clone(),
                     )?;
                 }


### PR DESCRIPTION
## Summary
- add `--allow-reserved` flag to `rlvgl-creator bsp from-ioc`
- wire flag through BSP generator
- document flag and enable in BSP generation script

## Testing
- ⚠️ `cargo check --bin rlvgl-creator --features creator` (partial, aborted after long build)


------
https://chatgpt.com/codex/tasks/task_e_68acfae85a048333aa7126a00e6877f8