### PR TITLE
fix: handle missing irq map entries

### DIFF
--- a/README-CREATOR.md
+++ b/README-CREATOR.md
@@ -47,6 +47,20 @@ Throughout the UI, status bars and log panes provide feedback, ensuring each act
 
 For detailed CLI and UI flags see [src/bin/creator/README.md](./src/bin/creator/README.md).
 
+## Template notes
+
+The creator's board and asset generators rely on [MiniJinja](https://github.com/mitsuhiko/minijinja),
+which does not implement Python-style `dict.get` methods. When accessing optional keys in a mapping,
+use bracket notation combined with the `default` filter instead. For example:
+
+```
+{%- for irq in (irq_map[name] | default([])) %}
+    ...
+{%- endfor %}
+```
+
+This pattern safely expands to an empty list when `name` is absent.
+
 ## Chip and board database integration
 
 `rlvgl-creator` consumes chip and board definitions from the `rlvgl-chips-*` crates under
@@ -70,4 +84,11 @@ rlvgl-creator board from-ioc project.ioc MyBoard MyBoard.json
 The CLI detects the MCU automatically and resolves alternate-function numbers
 using the bundled database. The resulting JSON can be placed under `boards/`
 for use by `rlvgl-creator`.
+
+## Batch BSP generation
+
+Run `scripts/gen_ioc_bsps.sh` to convert every CubeMX `.ioc` under
+`chips/stm/STM32_open_pin_data/boards`. The script invokes
+`rlvgl-creator` for each file and relies on the `rlvgl-chips-stm`
+archive for MCU metadata, so no standalone `mcu.json` is required.
 

--- a/chips/stm/bsps/README.md
+++ b/chips/stm/bsps/README.md
@@ -1,15 +1,17 @@
+<!--
+chips/stm/bsps/README.md - STM32 BSP stub generation notes.
+-->
 # rlvgl-stm-bsps
 
 Board support package stubs for STM32 boards used by `rlvgl-creator`.
 This crate now includes simple modules generated from CubeMX `.ioc`
 files with basic pin mappings.
 
-Use `tools/gen_bsps.py` to convert STM32CubeMX `.ioc` files into
-Rust modules within this crate:
-
-```
-python tools/gen_bsps.py --input path/to/ioc --output chips/stm/bsps/src
-```
+Regenerate the stubs with `scripts/gen_ioc_bsps.sh`. The script invokes
+`rlvgl-creator` for every `.ioc` under
+`chips/stm/STM32_open_pin_data/boards` and writes the modules to
+`chips/stm/bsps/src`. MCU data comes from the bundled `rlvgl-chips-stm`
+archive, so no separate `mcu.json` is needed.
 
 ## Available boards
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG.md - Notes on chip & board database releases.
 - Initial vendor crates for STM, Nordic, Espressif, NXP, Silicon Labs, Microchip, Renesas, Texas Instruments, and RP2040 boards.
 - Added `tools/bump_vendor_versions.py` to bump crate versions after regenerating pin data.
 - Documented creator integration with vendor crates so board selections reflect the bundled databases.
-- Introduced `st_ioc_board.py` to convert CubeMX `.ioc` files into board overlays.
+- Added `scripts/gen_ioc_bsps.sh` to batch-convert CubeMX `.ioc` files using `rlvgl-creator`.
 - `rlvgl-creator` can now load canonical MCU definitions alongside board overlays from vendor archives.
 - Added `rlvgl-creator board from-ioc` to convert user CubeMX projects into board overlays.
 - Added `--allow-reserved` flag to `rlvgl-creator bsp from-ioc` to permit SWD pins `PA13`/`PA14`.

--- a/docs/IOC-IR-ALIGNMENT.md
+++ b/docs/IOC-IR-ALIGNMENT.md
@@ -4,7 +4,7 @@ Plan for aligning CubeMX `.ioc` board overlays with canonical IR and Rust init t
 # STM32 Board IR Alignment Plan
 
 ## Current gap
-- `st_extract_af.py`/`st_ioc_board.py` emit pin → signal → AF maps only.
+- The current importer emits pin → signal → AF maps only.
 - Templates require per-pin context: port/index, class, mode, pull, speed, otype, EXTI, etc.
 
 ## Plan

--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -252,7 +252,7 @@ pub fn deinit_board_hal(dp: &pac::Peripherals) {
         "usart1": ["USART1"],
     } -%}
     {%- for name, _per in spec.peripherals | dictsort %}
-        {%- for irq in irq_map.get(name, []) %}
+        {%- for irq in (irq_map[name] | default([])) %}
     unsafe { pac::NVIC::mask(pac::Interrupt::{{ irq }}); }
         {%- endfor %}
     {%- endfor %}


### PR DESCRIPTION
## Summary
- avoid MiniJinja `map.get` calls in BSP `hal.rs.jinja`
- document MiniJinja's lack of `dict.get` and show bracket + default pattern
- remove obsolete `mcu.json` references and document `gen_ioc_bsps.sh` workflow

## Testing
- `scripts/gen_ioc_bsps.sh` *(fails: rlvgl-creator not found at target/debug/rlvgl-creator)*

------
https://chatgpt.com/codex/tasks/task_e_68ad00240eb48333acc4e1a5aabf2d2d