### PR TITLE
fix pac NVIC mask template

### DIFF
--- a/chipdb/rlvgl-chips-stm/build.rs
+++ b/chipdb/rlvgl-chips-stm/build.rs
@@ -5,10 +5,14 @@ Reads board definition files from the directory specified by the
 `RLVGL_CHIP_SRC` environment variable and packs them into a single
 binary blob at build time.
 */
-use std::{env, fs, io::Write, path::PathBuf};
+use std::{
+    env, fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 /// Compresses `input` into `output` using zstd level 19.
-fn compress_zstd(input: &PathBuf, output: &PathBuf) {
+fn compress_zstd(input: &Path, output: &Path) {
     let data = fs::read(input).expect("read uncompressed");
     let file = fs::File::create(output).expect("create zst");
     let mut encoder = zstd::Encoder::new(file, 19).expect("encoder");
@@ -16,7 +20,7 @@ fn compress_zstd(input: &PathBuf, output: &PathBuf) {
     encoder.finish().expect("finish zst");
 }
 
-fn copy_asset(out_dir: &PathBuf) -> bool {
+fn copy_asset(out_dir: &Path) -> bool {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let asset = manifest.join("assets/chipdb.bin.zst");
     if asset.exists() {

--- a/src/bin/creator/boards.rs
+++ b/src/bin/creator/boards.rs
@@ -5,6 +5,7 @@
 //! the creator CLI and UI to populate drop-downs without depending on vendor
 //! internals.
 
+use minijinja::{Environment, context};
 use rlvgl_chips_esp as esp;
 use rlvgl_chips_microchip as microchip;
 use rlvgl_chips_nrf as nrf;
@@ -12,15 +13,14 @@ use rlvgl_chips_nxp as nxp;
 use rlvgl_chips_renesas as renesas;
 use rlvgl_chips_rp2040 as rp2040;
 use rlvgl_chips_silabs as silabs;
-use rlvgl_stm_bsps as stm;
 use rlvgl_chips_stm as stm_db;
 use rlvgl_chips_ti as ti;
+use rlvgl_stm_bsps as stm;
+use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::io::Read;
 use zstd::stream::read::Decoder;
-use minijinja::{Environment, context};
-use serde::Serialize;
 #[cfg(test)]
 mod test_vendor {
     use std::sync::OnceLock;
@@ -52,7 +52,10 @@ mod test_vendor {
     }
 
     pub fn boards() -> &'static [BoardInfo] {
-        &[BoardInfo { board: "demo", chip: "STM32F4" }]
+        &[BoardInfo {
+            board: "demo",
+            chip: "STM32F4",
+        }]
     }
 
     pub fn find(board: &str) -> Option<BoardInfo> {
@@ -245,7 +248,8 @@ pub fn render_template(vendor: &str, board: &str, template: &str) -> Result<Stri
     let (board_val, mcu_val) = load_ir(vendor, board)?;
     let info = find_board(vendor, board)?;
     let mut env = Environment::new();
-    env.add_template("user", template).map_err(|e| e.to_string())?;
+    env.add_template("user", template)
+        .map_err(|e| e.to_string())?;
     let ctx = context! { board => board_val, mcu => mcu_val, meta => info };
     env.get_template("user")
         .and_then(|t| t.render(ctx))

--- a/src/bin/creator/bsp/templates/lib.rs.jinja
+++ b/src/bin/creator/bsp/templates/lib.rs.jinja
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+//! Board support package stubs for STM32 devices.
+//!
+//! This crate hosts board modules generated from STM32CubeMX `.ioc`
+//! definitions. Each supported board exposes a [`BoardInfo`] describing
+//! its name, MCU, and pin assignments.
+
+#![no_std]
+
+/// Pin mapping for a board.
+pub struct PinInfo {
+    /// Pin identifier, e.g., "PA0".
+    pub pin: &'static str,
+    /// Pin signal function.
+    pub signal: &'static str,
+}
+
+/// Information about a supported board.
+pub struct BoardInfo {
+    /// Board's human-friendly name.
+    pub board: &'static str,
+    /// Associated microcontroller name.
+    pub chip: &'static str,
+    /// List of pin assignments.
+    pub pins: &'static [PinInfo],
+}
+
+{%- for module in modules %}
+pub mod {{ module }};
+{%- endfor %}
+{%- for module in modules %}
+use {{ module }}::INFO as {{ module | upper }};
+{%- endfor %}
+const BOARDS: &[BoardInfo] = &[
+{%- for module in modules %}
+    {{ module | upper }},
+{%- endfor %}
+];
+
+/// Returns the vendor identifier.
+#[must_use]
+pub const fn vendor() -> &'static str {
+    "stm"
+}
+
+/// Returns the crate version.
+#[must_use]
+pub const fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Lists all available boards.
+#[must_use]
+pub fn boards() -> &'static [BoardInfo] {
+    BOARDS
+}
+
+/// Finds a board by name.
+#[must_use]
+pub fn find(name: &str) -> Option<&'static BoardInfo> {
+    BOARDS.iter().find(|b| b.board == name)
+}

--- a/src/bin/creator/bsp/templates/mod.rs.jinja
+++ b/src/bin/creator/bsp/templates/mod.rs.jinja
@@ -1,0 +1,4 @@
+{%- for module in modules %}
+#[cfg(feature = "{{ module }}")]
+pub mod {{ module }};
+{%- endfor %}

--- a/src/bin/creator/bsp/templates/pac.rs.jinja
+++ b/src/bin/creator/bsp/templates/pac.rs.jinja
@@ -44,6 +44,11 @@ use stm32h7::stm32h747 as pac;
 {%- endif -%}
 {%- endmacro %}
 
+{% if meta is defined %}
+/// Enables GPIO clocks required by {{ meta.board }}.
+{% else %}
+/// Enables GPIO clocks required by the generated board.
+{% endif %}
 pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
     {% set ns = namespace(ports=[]) %}
     {% for pin in spec.pinctrl %}{% if pin.pin[1] not in ns.ports %}{% set ns.ports = ns.ports + [pin.pin[1]] %}{% endif %}{% endfor %}
@@ -60,6 +65,11 @@ pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
     {% endif %}
 }
 
+{% if meta is defined %}
+/// Configures pins for {{ meta.board }} using PAC registers.
+{% else %}
+/// Configures pins using PAC registers.
+{% endif %}
 pub fn configure_pins_pac(dp: &pac::Peripherals) {
 {% if grouped_writes %}
     {% set ports = [] %}{% for pin in spec.pinctrl %}{% if pin.pin[1] not in ports %}{% set ports = ports + [pin.pin[1]] %}{% endif %}{% endfor %}
@@ -175,6 +185,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
 {% endif %}
 }
 
+{% if meta is defined %}
+/// Disables unused peripherals for {{ meta.board }} and masks their interrupts.
+{% else %}
+/// Disables unused peripherals and masks their interrupts.
+{% endif %}
 pub fn enable_peripherals(dp: &pac::Peripherals) {
 {%- set pairs = [] -%}
 {%- for name, _per in spec.peripherals | dictsort %}
@@ -212,6 +227,11 @@ pub fn enable_peripherals(dp: &pac::Peripherals) {
 }
 
 {% if with_deinit %}
+{% if meta is defined %}
+/// De-initializes {{ meta.board }} pins to their analog state.
+{% else %}
+/// De-initializes board pins to their analog state.
+{% endif %}
 pub fn deinit_board_pac(dp: &pac::Peripherals) {
     // Return pins to analog and remove pulls/open-drain
 {%- for pin in spec.pinctrl %}
@@ -332,23 +352,26 @@ pub fn deinit_board_pac(dp: &pac::Peripherals) {
     {%- endif %}
 
     // Disable interrupts
-{%- macro irq_list(name) -%}
-{%- if name == "i2c4" -%}["I2C4_EV", "I2C4_ER"]
-{%- elif name == "spi2" -%}["SPI2"]
-{%- elif name == "spi5" -%}["SPI5"]
-{%- elif name == "uart8" -%}["UART8"]
-{%- elif name == "usart1" -%}["USART1"]
-{%- else -%}[]
-{%- endif -%}
-{%- endmacro %}
-{%- for name, _per in spec.peripherals | dictsort %}
-    {%- for irq in irq_list(name) %}
+    {%- set irq_map = {
+        "i2c4": ["I2C4_EV", "I2C4_ER"],
+        "spi2": ["SPI2"],
+        "spi5": ["SPI5"],
+        "uart8": ["UART8"],
+        "usart1": ["USART1"],
+    } -%}
+    {%- for name, _per in spec.peripherals | dictsort %}
+        {%- for irq in (irq_map[name] | default([])) %}
     unsafe { pac::NVIC::mask(pac::Interrupt::{{ irq }}); }
+        {%- endfor %}
     {%- endfor %}
-{%- endfor %}
 }
 {% endif %}
 
+{% if meta is defined %}
+/// Initializes {{ meta.board }} using PAC register access.
+{% else %}
+/// Initializes the board using PAC register access.
+{% endif %}
 pub fn init_board_pac(dp: pac::Peripherals) {
     enable_gpio_clocks(&dp);
     configure_pins_pac(&dp);

--- a/tests/tools_gen_pins.rs
+++ b/tests/tools_gen_pins.rs
@@ -1,7 +1,7 @@
 //! Tests for the `gen_pins.py` helper script.
 
-use std::{fs, path::Path, process::Command};
 use serde_json::Value;
+use std::{fs, path::Path, process::Command};
 
 #[test]
 fn copies_mcu_definition() {

--- a/tools/gen_bsps.py
+++ b/tools/gen_bsps.py
@@ -5,6 +5,7 @@ import argparse
 import subprocess
 import tempfile
 from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
 
 
 def main() -> None:
@@ -40,6 +41,14 @@ def main() -> None:
             check=True,
         )
         tmp_json.unlink(missing_ok=True)
+
+    tmpl_path = Path(__file__).resolve().parents[1] / "src/bin/creator/bsp/templates"
+    env = Environment(loader=FileSystemLoader(tmpl_path))
+    tmpl = env.get_template("lib.rs.jinja")
+    modules = sorted(
+        p.stem for p in args.output.glob("*.rs") if p.name not in {"lib.rs", "mod.rs"}
+    )
+    args.output.joinpath("lib.rs").write_text(tmpl.render(modules=modules))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix NVIC interrupt masking list in PAC template
- document PAC template functions
- fix clippy warning in STM chipdb build script
- template-driven BSP module and crate scaffolding

## Testing
- `cargo fmt --all`
- `cargo fmt --all -- --check` *(fails: diffs in chips/stm/bsps and examples/stm32h747i-disco)*
- `cargo test --test tools_gen_pins`


------
https://chatgpt.com/codex/tasks/task_e_68ad6e3ff0108333b383062459654e2d