### PR TITLE
Add BSP generator logging and template docs

### DIFF
--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -8,6 +8,11 @@
  * Board: {{ meta.board }} ({{ meta.chip }})
 {% endif %}
  */
+{% if meta is defined %}
+//! HAL BSP for {{ meta.board }}.
+{% else %}
+//! HAL BSP for the generated board.
+{% endif %}
 #![allow(non_snake_case)]
 #![allow(clippy::too_many_arguments)]
 {% if mod_name %}#![cfg(feature = "{{ mod_name }}")]{% endif %}
@@ -46,6 +51,11 @@ use stm32h7xx_hal::{pac, prelude::*, gpio::Speed};
 {%- endif -%}
 {%- endmacro %}
 
+{% if meta is defined %}
+/// Enables GPIO clocks required by {{ meta.board }}.
+{% else %}
+/// Enables GPIO clocks required by the generated board.
+{% endif %}
 pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
     {% set ns = namespace(ports=[]) %}
     {% for pin in spec.pinctrl %}{% if pin.pin[1] not in ns.ports %}{% set ns.ports = ns.ports + [pin.pin[1]] %}{% endif %}{% endfor %}
@@ -62,6 +72,11 @@ pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
     {% endif %}
 }
 
+{% if meta is defined %}
+/// Configures pins for {{ meta.board }} using the HAL API.
+{% else %}
+/// Configures pins using the HAL API.
+{% endif %}
 pub fn configure_pins_hal() {
 {%- for pin in spec.pinctrl %}
     {%- set is_gpio = pin.func[0:5] == "GPIO_" %}
@@ -87,6 +102,11 @@ pub fn configure_pins_hal() {
 {%- endfor %}
 }
 
+{% if meta is defined %}
+/// Enables peripheral clocks for {{ meta.board }}.
+{% else %}
+/// Enables peripheral clocks for the generated board.
+{% endif %}
 pub fn enable_peripherals(dp: &pac::Peripherals) {
 {%- set pairs = [] -%}
 {%- for name, _per in spec.peripherals | dictsort %}
@@ -124,6 +144,11 @@ pub fn enable_peripherals(dp: &pac::Peripherals) {
 }
 
 {% if with_deinit %}
+{% if meta is defined %}
+/// De-initializes {{ meta.board }} peripherals and clocks.
+{% else %}
+/// De-initializes board peripherals and clocks.
+{% endif %}
 pub fn deinit_board_hal(dp: &pac::Peripherals) {
     // Return pins to analog and remove pulls/open-drain
 {%- for pin in spec.pinctrl %}
@@ -259,6 +284,11 @@ pub fn deinit_board_hal(dp: &pac::Peripherals) {
 }
 {% endif %}
 
+{% if meta is defined %}
+/// Initializes {{ meta.board }} using HAL drivers.
+{% else %}
+/// Initializes the board using HAL drivers.
+{% endif %}
 pub fn init_board_hal(dp: pac::Peripherals /*, clocks */) {
     enable_gpio_clocks(&dp);
     configure_pins_hal();

--- a/src/bin/creator/bsp/templates/mod.rs.jinja
+++ b/src/bin/creator/bsp/templates/mod.rs.jinja
@@ -1,3 +1,4 @@
+//! Generated board modules.
 {%- for module in modules %}
 #[cfg(feature = "{{ module }}")]
 pub mod {{ module }};

--- a/src/bin/creator/bsp/templates/pac.rs.jinja
+++ b/src/bin/creator/bsp/templates/pac.rs.jinja
@@ -8,6 +8,11 @@
  * Board: {{ meta.board }} ({{ meta.chip }})
 {% endif %}
  */
+{% if meta is defined %}
+//! PAC BSP for {{ meta.board }}.
+{% else %}
+//! PAC BSP for the generated board.
+{% endif %}
 #![allow(non_snake_case)]
 #![allow(clippy::too_many_arguments)]
 {% if mod_name %}#![cfg(feature = "{{ mod_name }}")]{% endif %}
@@ -190,6 +195,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
 {% else %}
 /// Disables unused peripherals and masks their interrupts.
 {% endif %}
+{% if meta is defined %}
+/// Enables peripheral clocks for {{ meta.board }} using PAC registers.
+{% else %}
+/// Enables peripheral clocks for the generated board using PAC registers.
+{% endif %}
 pub fn enable_peripherals(dp: &pac::Peripherals) {
 {%- set pairs = [] -%}
 {%- for name, _per in spec.peripherals | dictsort %}
@@ -231,6 +241,11 @@ pub fn enable_peripherals(dp: &pac::Peripherals) {
 /// De-initializes {{ meta.board }} pins to their analog state.
 {% else %}
 /// De-initializes board pins to their analog state.
+{% endif %}
+{% if meta is defined %}
+/// De-initializes {{ meta.board }} peripherals and clocks using PAC registers.
+{% else %}
+/// De-initializes board peripherals and clocks using PAC registers.
 {% endif %}
 pub fn deinit_board_pac(dp: &pac::Peripherals) {
     // Return pins to analog and remove pulls/open-drain
@@ -367,6 +382,11 @@ pub fn deinit_board_pac(dp: &pac::Peripherals) {
 }
 {% endif %}
 
+{% if meta is defined %}
+/// Initializes {{ meta.board }} using PAC register access.
+{% else %}
+/// Initializes the board using PAC register access.
+{% endif %}
 {% if meta is defined %}
 /// Initializes {{ meta.board }} using PAC register access.
 {% else %}

--- a/tests/creator_board_import.rs
+++ b/tests/creator_board_import.rs
@@ -22,7 +22,7 @@ fn imports_custom_ioc() {
     let ioc = data_dir.join("sample.ioc");
     let tmp = tempdir().unwrap();
     let out = tmp.path().join("board.json");
-    board_import::from_ioc(&ioc, "MyBoard", &out).expect("convert");
+    board_import::from_ioc(&ioc, "MyBoard", &out, None).expect("convert");
     let text = std::fs::read_to_string(&out).unwrap();
     let json: serde_json::Value = serde_json::from_str(&text).unwrap();
     assert_eq!(json["board"], "MyBoard");


### PR DESCRIPTION
## Summary
- log board progress in `gen_ioc_bsps.sh`
- document BSP templates and their public helpers
- fix board import test for new API
- derive short board slugs from `.ioc` filenames

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo build --bin rlvgl-creator --features creator`
- `OPEN_PIN_DATA=tmp_ioc OUT_DIR=tmp_bsps scripts/gen_ioc_bsps.sh`
- `cargo build -p rlvgl-stm-bsps`
- `scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad8139c1e48333ae98ec1d2afecb35