### PR TITLE
Improve STM32 board name parsing

### DIFF
--- a/scripts/gen_ioc_bsps.sh
+++ b/scripts/gen_ioc_bsps.sh
@@ -39,7 +39,21 @@ for ioc in "${iocs[@]}"; do
   count=$((count + 1))
   raw="$(basename "$ioc" .ioc)"
   IFS='_' read -r -a parts <<<"$raw"
-  board="${parts[2]:-$raw}"
+  parts=("${parts[@]:1}")
+  board=""
+  for part in "${parts[@]}"; do
+    lpart="$(echo "$part" | tr '[:upper:]' '[:lower:]')"
+    case "$lpart" in
+      nucleo|discovery|evaluation|connectivity|expansion|board)
+        continue
+        ;;
+      *)
+        board="$part"
+        break
+        ;;
+    esac
+  done
+  board="${board:-$raw}"
   board="$(echo "$board" | tr '[:upper:]' '[:lower:]' | tr '-' '_')"
   echo "[$count/$total] $board"
   out_dir="$OUT_DIR/$board"


### PR DESCRIPTION
## Summary
- handle STM32 board name parsing by skipping category tokens

## Testing
- `cargo fmt --all`
- `./scripts/pre-commit.sh` *(fails: unresolved import `minijinja`)*

------
https://chatgpt.com/codex/tasks/task_e_68adc99eb8108333871be95e7954194e