### PR TITLE
Drop STM board list from creator UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,10 +191,6 @@ optional = true
 version = "0.15"
 optional = true
 
-[dependencies.rlvgl-stm-bsps]
-path = "chips/stm/bsps"
-optional = true
-
 [dependencies.rlvgl-chips-stm]
 path = "chipdb/rlvgl-chips-stm"
 optional = true
@@ -296,7 +292,6 @@ creator = [
     "dep:rayon",
     "dep:resvg",
     "dep:zstd",
-    "dep:rlvgl-stm-bsps",
     "dep:rlvgl-chips-stm",
     "dep:rlvgl-chips-nrf",
     "dep:rlvgl-chips-esp",
@@ -323,7 +318,6 @@ creator_ui = [
     "dep:rfd",
     "dep:serde_json",
     "dep:zstd",
-    "dep:rlvgl-stm-bsps",
     "dep:rlvgl-chips-stm",
     "dep:rlvgl-chips-nrf",
     "dep:rlvgl-chips-esp",

--- a/chips/stm/bsps/Cargo.toml
+++ b/chips/stm/bsps/Cargo.toml
@@ -1,6 +1,3 @@
-# SPDX-License-Identifier: MIT
-# rlvgl-stm-bsps crate manifest.
-
 [package]
 name = "rlvgl-stm-bsps"
 version = "0.1.0"
@@ -12,7 +9,10 @@ description = "Board support package stubs for STM32 devices."
 path = "src/lib.rs"
 
 [features]
-default = ["hal", "split"]
+default = [
+    "hal",
+    "split",
+]
 hal = []
 pac = []
 split = []
@@ -20,7 +20,3 @@ flat = []
 summaries = []
 pinreport = []
 stm32-f4 = []
-stm32-h7 = []
-stm32-l4 = []
-stm32-c0 = []
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ referencing==0.36.2
 requests==2.32.4
 rpds-py==0.27.0
 six==1.17.0
+tomli-w==1.2.0
 typing_extensions==4.14.1
 urllib3==2.0.7
 zstandard==0.22.0

--- a/scripts/gen_ioc_bsps.sh
+++ b/scripts/gen_ioc_bsps.sh
@@ -73,3 +73,7 @@ echo "Generating lib.rs..."
   --prelude hal:split \
   --features hal,pac,split,flat,summaries,pinreport \
   --family-feature-prefix stm32- || echo "warning: gen-lib failed" >&2
+
+# Synchronize stm32-* feature flags in the BSP crate after regeneration.
+echo "Updating Cargo feature flags..."
+python tools/update_stm_bsp_features.py || echo "warning: feature sync failed" >&2

--- a/src/bin/creator/boards.rs
+++ b/src/bin/creator/boards.rs
@@ -13,9 +13,7 @@ use rlvgl_chips_nxp as nxp;
 use rlvgl_chips_renesas as renesas;
 use rlvgl_chips_rp2040 as rp2040;
 use rlvgl_chips_silabs as silabs;
-use rlvgl_chips_stm as stm_db;
 use rlvgl_chips_ti as ti;
-use rlvgl_stm_bsps as stm;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -78,13 +76,6 @@ pub struct VendorBoard {
 #[must_use]
 pub fn enumerate() -> Vec<VendorBoard> {
     let mut out = Vec::new();
-    for b in stm::boards() {
-        out.push(VendorBoard {
-            vendor: stm::vendor(),
-            board: b.board,
-            chip: b.chip,
-        });
-    }
     for b in nrf::boards() {
         out.push(VendorBoard {
             vendor: nrf::vendor(),
@@ -164,7 +155,6 @@ pub fn find_board(vendor: &str, board: &str) -> Result<VendorBoard, String> {
             }
         }};
     }
-    check_vendor!(stm);
     check_vendor!(nrf);
     check_vendor!(esp);
     check_vendor!(nxp);
@@ -210,7 +200,6 @@ fn parse_raw_db(blob: &[u8]) -> HashMap<String, Vec<u8>> {
 pub fn load_ir(vendor: &str, board: &str) -> Result<(Value, Value), String> {
     let info = find_board(vendor, board)?;
     let blob = match vendor {
-        v if v == stm::vendor() => stm_db::raw_db(),
         v if v == nrf::vendor() => nrf::raw_db(),
         v if v == esp::vendor() => esp::raw_db(),
         v if v == nxp::vendor() => nxp::raw_db(),


### PR DESCRIPTION
## Summary
- remove STM board list usage from creator tooling
- add helper script to sync stm32-* BSP features
- integrate feature sync into BSP generation script and record Python dependency

## Testing
- `pip install -r requirements.txt`
- `cargo build --bin rlvgl-creator --features creator,creator_ui`
- `target/debug/rlvgl-creator bsp from-ioc tests/fixtures/simple.ioc stm32_af.json --emit-hal --emit-pac --out /tmp/bsp`
- `cargo test --test bsp_roundtrip`
- `cargo test --test bsp_reserved_pins`
- `python tools/update_stm_bsp_features.py`


------
https://chatgpt.com/codex/tasks/task_e_68add7d1836483338905ccf9043b546e