### PR TITLE
Skip board init in per-peripheral PAC templates

### DIFF
--- a/src/bin/creator/bsp/templates/pac.rs.jinja
+++ b/src/bin/creator/bsp/templates/pac.rs.jinja
@@ -379,6 +379,7 @@ pub fn deinit_board_pac(dp: &pac::Peripherals) {
 }
 {% endif %}
 
+{% if mod_name is not defined %}
 {% if meta is defined %}
 /// Initializes {{ meta.board }} using PAC register access.
 {% else %}
@@ -394,3 +395,4 @@ pub fn init_board_pac(dp: pac::Peripherals) {
     configure_pins_pac(&dp);
     enable_peripherals(&dp);
 }
+{% endif %}

--- a/tests/creator_gen_lib.rs
+++ b/tests/creator_gen_lib.rs
@@ -97,3 +97,24 @@ fn templates_skip_empty_pin_fns() {
         .unwrap();
     assert!(!hal.contains("pub fn configure_pins_hal"));
 }
+
+#[test]
+fn pac_split_omits_board_init() {
+    let mut env = Environment::new();
+    env.add_template(
+        "pac",
+        include_str!("../src/bin/creator/bsp/templates/pac.rs.jinja"),
+    )
+    .unwrap();
+    let spec = context! {
+        mcu => "STM32F0",
+        pinctrl => Vec::<String>::new(),
+        peripherals => BTreeMap::<String, String>::new(),
+    };
+    let pac = env
+        .get_template("pac")
+        .unwrap()
+        .render(context! { spec => spec, grouped_writes => true, with_deinit => false, mod_name => "foo" })
+        .unwrap();
+    assert!(!pac.contains("init_board_pac"));
+}


### PR DESCRIPTION
## Summary
- avoid generating `init_board_pac` in per-peripheral PAC BSP outputs
- test that per-peripheral PAC templates omit board init function

## Testing
- `cargo fmt --all`
- `./scripts/pre-commit.sh` *(fails: interrupted)*
- `cargo test --test creator_gen_lib --features creator` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ae194c748483338d23aa781220a85d