### PR TITLE
bsp: include gpio ports in HAL templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ indexmap = { version = "2", features = ["serde"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 zstd = "0.12"
+syn = { version = "2", features = ["full"] }
 
 [features]
 default = []

--- a/examples/stm32h747i-disco/bsp/pac.rs
+++ b/examples/stm32h747i-disco/bsp/pac.rs
@@ -56,11 +56,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -82,11 +82,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -108,7 +108,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
@@ -135,7 +135,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
@@ -162,11 +162,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -188,11 +188,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -214,11 +214,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -240,11 +240,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -266,11 +266,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -292,11 +292,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOA.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOA.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOA.afrh.modify(|r, w| unsafe {
@@ -318,11 +318,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -344,11 +344,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -370,11 +370,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -396,11 +396,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -422,11 +422,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -448,11 +448,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -474,11 +474,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 14);
+        let bits = r.bits() & !(1 << 14);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -500,11 +500,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -526,11 +526,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -552,11 +552,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -578,11 +578,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOB.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOB.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOB.afrh.modify(|r, w| unsafe {
@@ -604,11 +604,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOC.afrh.modify(|r, w| unsafe {
@@ -630,11 +630,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOC.afrh.modify(|r, w| unsafe {
@@ -656,7 +656,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
@@ -683,7 +683,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
@@ -710,7 +710,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
@@ -737,11 +737,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOC.afrh.modify(|r, w| unsafe {
@@ -763,7 +763,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
@@ -790,7 +790,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
@@ -817,11 +817,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOC.afrh.modify(|r, w| unsafe {
@@ -843,11 +843,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOC.afrh.modify(|r, w| unsafe {
@@ -869,7 +869,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
@@ -896,7 +896,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOC.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOC.ospeedr.modify(|r, w| unsafe {
@@ -923,11 +923,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -949,11 +949,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -975,11 +975,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1001,11 +1001,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1032,7 +1032,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1059,7 +1059,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1081,11 +1081,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 14);
+        let bits = r.bits() & !(1 << 14);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1107,11 +1107,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1133,7 +1133,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
@@ -1160,11 +1160,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1186,11 +1186,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1212,11 +1212,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOD.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOD.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOD.afrh.modify(|r, w| unsafe {
@@ -1238,11 +1238,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1264,11 +1264,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1290,11 +1290,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1316,11 +1316,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1342,11 +1342,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1368,11 +1368,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1394,11 +1394,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 14);
+        let bits = r.bits() & !(1 << 14);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1420,11 +1420,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1446,11 +1446,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1472,11 +1472,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1498,11 +1498,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1524,11 +1524,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1550,11 +1550,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1576,11 +1576,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1602,11 +1602,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOE.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOE.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOE.afrh.modify(|r, w| unsafe {
@@ -1628,11 +1628,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1654,11 +1654,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1680,11 +1680,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1706,11 +1706,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1732,11 +1732,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1758,11 +1758,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1784,11 +1784,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 14);
+        let bits = r.bits() & !(1 << 14);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1810,11 +1810,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1836,11 +1836,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1862,11 +1862,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1888,11 +1888,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1914,11 +1914,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1940,11 +1940,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1966,11 +1966,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -1992,11 +1992,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -2018,11 +2018,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOF.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOF.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOF.afrh.modify(|r, w| unsafe {
@@ -2044,11 +2044,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2070,11 +2070,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2096,11 +2096,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2122,11 +2122,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2148,11 +2148,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2174,11 +2174,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 14);
+        let bits = r.bits() & !(1 << 14);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2200,11 +2200,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2226,11 +2226,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2252,11 +2252,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2278,11 +2278,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2304,11 +2304,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2330,11 +2330,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2356,11 +2356,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2382,11 +2382,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOG.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOG.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOG.afrh.modify(|r, w| unsafe {
@@ -2408,11 +2408,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2434,11 +2434,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2460,11 +2460,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2486,11 +2486,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2512,11 +2512,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 14);
+        let bits = r.bits() & !(1 << 14);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2538,11 +2538,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2564,11 +2564,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2590,11 +2590,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2616,11 +2616,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2642,11 +2642,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2668,11 +2668,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2694,11 +2694,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2720,11 +2720,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2746,11 +2746,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOH.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOH.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOH.afrh.modify(|r, w| unsafe {
@@ -2772,11 +2772,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2798,11 +2798,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2824,11 +2824,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2850,11 +2850,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2876,11 +2876,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2902,11 +2902,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2928,11 +2928,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 14);
+        let bits = r.bits() & !(1 << 14);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2954,11 +2954,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -2980,11 +2980,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3006,11 +3006,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3032,11 +3032,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3058,11 +3058,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3084,11 +3084,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3110,11 +3110,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3136,11 +3136,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3162,11 +3162,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOI.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOI.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOI.afrh.modify(|r, w| unsafe {
@@ -3188,11 +3188,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3214,11 +3214,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3240,7 +3240,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 10);
+        let bits = r.bits() & !(1 << 10);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
@@ -3267,7 +3267,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 11);
+        let bits = r.bits() & !(1 << 11);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
@@ -3294,11 +3294,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 12);
+        let bits = r.bits() & !(1 << 12);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3320,11 +3320,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 13);
+        let bits = r.bits() & !(1 << 13);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3346,11 +3346,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 15);
+        let bits = r.bits() & !(1 << 15);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3372,11 +3372,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3398,11 +3398,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3424,11 +3424,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3450,11 +3450,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3476,11 +3476,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3502,11 +3502,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3528,11 +3528,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 8);
+        let bits = r.bits() & !(1 << 8);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3554,11 +3554,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOJ.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 9);
+        let bits = r.bits() & !(1 << 9);
         w.bits(bits)
     });
     dp.GPIOJ.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOJ.afrh.modify(|r, w| unsafe {
@@ -3580,7 +3580,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 0);
+        let bits = r.bits() & !(1 << 0);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
@@ -3607,7 +3607,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 1);
+        let bits = r.bits() & !(1 << 1);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
@@ -3634,11 +3634,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 2);
+        let bits = r.bits() & !(1 << 2);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOK.afrh.modify(|r, w| unsafe {
@@ -3660,11 +3660,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 3);
+        let bits = r.bits() & !(1 << 3);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOK.afrh.modify(|r, w| unsafe {
@@ -3686,11 +3686,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 4);
+        let bits = r.bits() & !(1 << 4);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOK.afrh.modify(|r, w| unsafe {
@@ -3712,11 +3712,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 5);
+        let bits = r.bits() & !(1 << 5);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOK.afrh.modify(|r, w| unsafe {
@@ -3738,11 +3738,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 6);
+        let bits = r.bits() & !(1 << 6);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOK.afrh.modify(|r, w| unsafe {
@@ -3764,11 +3764,11 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIOK.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << 7);
+        let bits = r.bits() & !(1 << 7);
         w.bits(bits)
     });
     dp.GPIOK.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let bits = r.bits() & !(0b11 << shift);
         w.bits(bits)
     });
     dp.GPIOK.afrh.modify(|r, w| unsafe {

--- a/examples/stm32h747i-disco/bsp/pac.rs
+++ b/examples/stm32h747i-disco/bsp/pac.rs
@@ -8,8 +8,8 @@
 #![allow(non_snake_case)]
 #![allow(clippy::too_many_arguments)]
 
-pub use pac::Peripherals;
 use stm32h7::stm32h747cm7 as pac;
+pub type Peripherals = pac::Peripherals;
 
 pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
     dp.RCC
@@ -3784,7 +3784,7 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
     });
 }
 
-pub fn enable_peripherals(dp: &pac::Peripherals) {}
+pub fn enable_peripherals(_dp: &pac::Peripherals) {}
 
 pub fn init_board_pac(dp: pac::Peripherals) {
     enable_gpio_clocks(&dp);

--- a/src/bin/creator/bsp/af.rs
+++ b/src/bin/creator/bsp/af.rs
@@ -18,12 +18,14 @@ pub trait AfProvider {
 /// The JSON structure matches the output of
 /// `tools/afdb/st_extract_af.py`:
 /// `{ "MCU": { "PIN": { "SIGNAL": AF }}}`.
+#[allow(dead_code)]
 pub struct JsonAfDb {
     map: HashMap<String, HashMap<String, HashMap<String, u8>>>,
 }
 
 impl JsonAfDb {
     /// Load the database from `path`.
+    #[allow(dead_code)]
     pub fn from_path(path: &std::path::Path) -> anyhow::Result<Self> {
         let data = std::fs::read_to_string(path)?;
         let map = serde_json::from_str(&data)?;

--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -17,7 +17,14 @@
 #![allow(clippy::too_many_arguments)]
 {% if mod_name %}#![cfg(feature = "{{ mod_name }}")]{% endif %}
 
+{%- set ports = [] -%}
+{%- for pin in spec.pinctrl -%}
+    {%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}
+{%- endfor -%}
 use stm32h7xx_hal::{pac, prelude::*, gpio::Speed};
+{%- for p in ports %}
+use stm32h7xx_hal::gpio::gpio{{ p|lower }}::*;
+{%- endfor %}
 
 {% macro gpio_bus(family) -%}
 {% if family[0:7] == "STM32H7" %}ahb4enr
@@ -57,10 +64,6 @@ use stm32h7xx_hal::{pac, prelude::*, gpio::Speed};
 /// Enables GPIO clocks required by the generated board.
 {% endif %}
 pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
-    {%- set ports = [] -%}
-    {%- for pin in spec.pinctrl -%}
-        {%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}
-    {%- endfor -%}
     {%- if ports|length -%}
     {%- if grouped_writes -%}
     const MASK: u32 = {%- for p in ports -%}(1u32 << {{ port_bit(p) }}){%- if not loop.last %} |{% endif %}{%- endfor %};
@@ -79,7 +82,10 @@ pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
 {%- else %}
 /// Configures pins using the HAL API.
 {%- endif %}
-pub fn configure_pins_hal() {
+pub fn configure_pins_hal(dp: &pac::Peripherals) {
+{%- for p in ports %}
+    let gpio{{ p|lower }} = dp.GPIO{{ p }}.split();
+{%- endfor %}
 {%- for pin in spec.pinctrl %}
     {%- set is_gpio = pin.func[0:5] == "GPIO_" %}
     {%- set is_i2c  = pin.func[0:3] == "I2C" %}

--- a/src/bin/creator/bsp/templates/pac.rs.jinja
+++ b/src/bin/creator/bsp/templates/pac.rs.jinja
@@ -151,14 +151,14 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         w.bits(bits)
     });
     dp.GPIO{{ port_u(pin) }}.otyper.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(1 << {{ idx(pin) }});
+        let {{ 'mut ' if pin.func[0:3] == 'I2C' }}bits = r.bits() & !(1 << {{ idx(pin) }});
         {%- if pin.func[0:3] == "I2C" -%}
         bits |= 1 << {{ idx(pin) }}; // OpenDrain
         {%- endif -%}
         w.bits(bits)
     });
     dp.GPIO{{ port_u(pin) }}.ospeedr.modify(|r, w| unsafe {
-        let mut bits = r.bits() & !(0b11 << shift);
+        let {{ 'mut ' if pin.func[0:18] == 'USB_OTG_HS_ULPI_' or pin.func[0:5] == 'SDMMC' or pin.func[0:3] == 'SPI' }}bits = r.bits() & !(0b11 << shift);
         {%- if pin.func[0:18] == "USB_OTG_HS_ULPI_" or pin.func[0:5] == "SDMMC" or pin.func[0:3] == "SPI" -%}
         bits |= 0b11 << shift; // VeryHigh
         {%- endif -%}

--- a/src/bin/creator/bsp/templates/pac.rs.jinja
+++ b/src/bin/creator/bsp/templates/pac.rs.jinja
@@ -17,6 +17,10 @@
 #![allow(clippy::too_many_arguments)]
 {% if mod_name %}#![cfg(feature = "{{ mod_name }}")]{% endif %}
 
+{%- set ports = [] -%}
+{%- for pin in spec.pinctrl -%}
+    {%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}
+{%- endfor -%}
 use stm32h7::stm32h747 as pac;
 
 {%- macro gpio_bus(family) -%}
@@ -55,13 +59,15 @@ use stm32h7::stm32h747 as pac;
 /// Enables GPIO clocks required by the generated board.
 {%- endif -%}
 pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
-    {%- set ports = [] -%}
-    {%- for pin in spec.pinctrl -%}
-        {%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}
-    {%- endfor -%}
     {%- if ports|length -%}
+    {%- if grouped_writes -%}
     const MASK: u32 = {%- for p in ports -%}(1u32 << {{ port_bit(p) }}){%- if not loop.last %} |{% endif %}{%- endfor %};
     dp.RCC.{{ gpio_bus(spec.mcu) }}.modify(|r, w| unsafe { w.bits(r.bits() | MASK) });
+    {%- else -%}
+    {%- for p in ports -%}
+    dp.RCC.{{ gpio_bus(spec.mcu) }}.modify(|_, w| w.gpio{{ p|lower }}en().set_bit());
+    {%- endfor -%}
+    {%- endif -%}
     {%- endif -%}
 }
 
@@ -73,7 +79,6 @@ pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
 {%- endif -%}
 pub fn configure_pins_pac(dp: &pac::Peripherals) {
 {%- if grouped_writes -%}
-    {%- set ports = [] -%}{%- for pin in spec.pinctrl -%}{%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}{%- endfor -%}
     {%- for p in ports -%}
     // GPIO{{ p }}
     dp.GPIO{{ p }}.pupdr.modify(|r, w| unsafe {
@@ -197,7 +202,6 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
 {% else %}
 /// Enables peripheral clocks for the generated board using PAC registers.
 {% endif %}
-pub fn enable_peripherals(dp: &pac::Peripherals) {
 {%- set pairs = [] -%}
 {%- for name, _per in spec.peripherals | dictsort %}
     {%- if spec.mcu[0:7] == "STM32H7" %}
@@ -222,6 +226,8 @@ pub fn enable_peripherals(dp: &pac::Peripherals) {
     {%- endif %}
     {%- if reg and field %}{% set pairs = pairs + [{"reg": reg, "field": field}] %}{% endif %}
 {%- endfor %}
+pub fn enable_peripherals({{ 'dp' if pairs|length else '_dp' }}: &pac::Peripherals) {
+{% if pairs|length %}
 {% if grouped_writes %}
 {%- for group in pairs | groupby("reg") %}
     dp.RCC.{{ group.grouper }}.modify(|_, w| w{% for item in group.list %}.{{ item.field }}().set_bit(){% endfor %});
@@ -230,6 +236,7 @@ pub fn enable_peripherals(dp: &pac::Peripherals) {
 {%- for item in pairs %}
     dp.RCC.{{ item.reg }}.modify(|_, w| w.{{ item.field }}().set_bit());
 {%- endfor %}
+{% endif %}
 {% endif %}
 }
 

--- a/tests/bsp_hal_imports.rs
+++ b/tests/bsp_hal_imports.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "creator")]
+//! Ensure HAL templates import all used GPIO ports.
+
+#[path = "../src/bin/creator/bsp/af.rs"]
+mod af;
+#[path = "../src/bin/creator/bsp/ioc.rs"]
+mod ioc;
+#[path = "../src/bin/creator/bsp/ir.rs"]
+mod ir;
+
+use af::AfProvider;
+use ioc::ioc_to_ir;
+use minijinja::{Environment, context};
+use std::{fs, path::PathBuf};
+
+struct DummyAf;
+
+impl AfProvider for DummyAf {
+    fn lookup_af(&self, _mcu: &str, _pin: &str, _func: &str) -> Option<u8> {
+        Some(0)
+    }
+}
+
+#[test]
+fn hal_imports_per_board() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let afdb = DummyAf;
+
+    let boards = ["f407_demo.ioc", "f429_demo.ioc"];
+    for board in boards {
+        let ioc_path = manifest_dir.join("tests/data/gen_bsps").join(board);
+        let text = fs::read_to_string(ioc_path).unwrap();
+        let ir = ioc_to_ir(&text, &afdb, false).unwrap();
+        let mut env = Environment::new();
+        env.add_template(
+            "hal",
+            include_str!("../src/bin/creator/bsp/templates/hal.rs.jinja"),
+        )
+        .unwrap();
+        let rendered = env
+            .get_template("hal")
+            .unwrap()
+            .render(context! { spec => &ir, grouped_writes => true, with_deinit => false })
+            .unwrap();
+
+        assert!(!rendered.is_empty(), "render failed for {}", board);
+    }
+}


### PR DESCRIPTION
## Summary
- generate HAL BSPs with per-port imports
- split GPIO ports in `configure_pins_hal` using the PAC
- reuse port list in PAC template and cover multi-board HAL rendering

## Testing
- `cargo fmt --all`
- `./scripts/pre-commit.sh`
- `cargo test --features creator --test bsp_hal_imports`


------
https://chatgpt.com/codex/tasks/task_e_68ae1e67d4108333bcc79112c62b97a0