### PR TITLE
rlvgl: fix HAL template pin configuration usage

### DIFF
--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -300,6 +300,6 @@ pub fn deinit_board_hal(dp: &pac::Peripherals) {
 {% endif %}
 pub fn init_board_hal(dp: pac::Peripherals /*, clocks */) {
     enable_gpio_clocks(&dp);
-    configure_pins_hal();
+    configure_pins_hal(&dp);
     enable_peripherals(&dp);
 }


### PR DESCRIPTION
## Summary
- pass device peripherals to generated `configure_pins_hal` calls

## Testing
- `cargo check -p rlvgl-bsps-stm --all-features`
- `./scripts/pre-commit.sh` *(fails: terminated after lengthy dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68ae50f9fc8883338b6755ccb7ec6f1c