### PR TITLE
feat(creator): import all used GPIO ports

### DIFF
--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -21,10 +21,7 @@
 {%- for pin in spec.pinctrl -%}
     {%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}
 {%- endfor -%}
-use stm32h7xx_hal::{pac, prelude::*, gpio::Speed};
-{%- for p in ports %}
-use stm32h7xx_hal::gpio::gpio{{ p|lower }}::*;
-{%- endfor %}
+use stm32h7xx_hal::{gpio::Speed, pac, prelude::*{% for p in ports %}, gpio{{ p|lower }}::*{% endfor %}};
 
 {% macro gpio_bus(family) -%}
 {% if family[0:7] == "STM32H7" %}ahb4enr


### PR DESCRIPTION
## Summary
- include all referenced GPIO port modules in generated HAL templates

## Testing
- `cargo fmt --all`
- `./scripts/pre-commit.sh` *(fails: terminated after lengthy dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68ae576bc9a88333ba6d82ab42fc08f7