### PR TITLE
fix STM32 BSP template port list

### DIFF
--- a/chips/stm/bsps/Cargo.toml
+++ b/chips/stm/bsps/Cargo.toml
@@ -1,10 +1,9 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# rlvgl-stm-bsps crate manifest.
-
 [package]
 name = "rlvgl-bsps-stm"
 version = "0.1.0"
-authors = ["Ira Abbott <ira@softoboros.com>"]
+authors = [
+    "Ira Abbott <ira@softoboros.com>",
+]
 edition = "2024"
 license = "BSD-3-Clause"
 description = "BSP files for STM32 Demo, Nucleo, and Discovery boards per vendor .ioc files."
@@ -12,8 +11,19 @@ readme = "README.md"
 repository = "https://github.com/softoboros/rlvgl"
 homepage = "https://github.com/softoboros/rlvgl"
 documentation = "https://docs.rs/rlvgl-bsps-stm"
-keywords = ["embedded", "graphics", "ui", "lvgl", "no_std"]
-categories = ["embedded", "gui", "no-std", "graphics"]
+keywords = [
+    "embedded",
+    "graphics",
+    "ui",
+    "lvgl",
+    "no_std",
+]
+categories = [
+    "embedded",
+    "gui",
+    "no-std",
+    "graphics",
+]
 publish = true
 
 [lib]
@@ -30,19 +40,65 @@ split = []
 flat = []
 summaries = []
 pinreport = []
-stm32-c0 = []
-stm32-f0 = []
-stm32-f3 = []
-stm32-f4 = []
-stm32-f7 = []
-stm32-g0 = []
-stm32-g4 = []
-stm32-h5 = []
-stm32-h7 = []
-stm32-l0 = []
-stm32-l1 = []
-stm32-l4 = []
-stm32-l5 = []
+i2c1 = []
+i2c2 = []
+i2c3 = []
+i2c4 = []
+i2c5 = []
+i2c7 = []
+i2c8 = []
+spi1 = []
+spi2 = []
+spi3 = []
+spi4 = []
+spi5 = []
+spi6 = []
+spi8 = []
+stm32-c0 = ["dep:stm32c0xx-hal"]
+stm32-f0 = ["dep:stm32f0xx-hal"]
+stm32-f3 = ["dep:stm32f3xx-hal"]
+stm32-f4 = ["dep:stm32f4xx-hal"]
+stm32-f7 = ["dep:stm32f7xx-hal"]
+stm32-g0 = ["dep:stm32g0xx-hal"]
+stm32-g4 = ["dep:stm32g4xx-hal"]
+stm32-h5 = ["dep:stm32h5xx-hal"]
+stm32-h7 = ["dep:stm32h7xx-hal"]
+stm32-l0 = ["dep:stm32l0xx-hal"]
+stm32-l1 = ["dep:stm32l1xx-hal"]
+stm32-l4 = ["dep:stm32l4xx-hal"]
+stm32-l5 = ["dep:stm32l5xx-hal"]
 stm32-n6 = []
 stm32-u0 = []
 stm32-u5 = []
+stm32-wb = ["dep:stm32wb-hal"]
+stm32-wl = ["dep:stm32wlxx-hal"]
+uart10 = []
+uart4 = []
+uart5 = []
+uart7 = []
+uart8 = []
+usart1 = []
+usart2 = []
+usart3 = []
+usart4 = []
+usart5 = []
+usart6 = []
+usart7 = []
+usart8 = []
+
+[dependencies]
+stm32c0xx-hal = { version = "0.0.0", optional = true, default-features = false }
+stm32f0xx-hal = { version = "0.18.0", optional = true, default-features = false }
+stm32f3xx-hal = { version = "0.10.0", optional = true, default-features = false }
+stm32f4xx-hal = { version = "0.22.1", optional = true, default-features = false }
+stm32f7xx-hal = { version = "0.8.0", optional = true, default-features = false }
+stm32g0xx-hal = { version = "0.2.0", optional = true, default-features = false }
+stm32g4xx-hal = { version = "0.0.1", optional = true, default-features = false }
+stm32h5xx-hal = { version = "0.0.0", optional = true, default-features = false }
+stm32h7xx-hal = { version = "0.16.0", optional = true, default-features = false }
+stm32l0xx-hal = { version = "0.10.0", optional = true, default-features = false }
+stm32l1xx-hal = { version = "0.1.0", optional = true, default-features = false }
+stm32l4xx-hal = { version = "0.7.1", optional = true, default-features = false }
+stm32l5xx-hal = { version = "0.0.0", optional = true, default-features = false }
+stm32wb-hal = { version = "0.1.14", optional = true, default-features = false }
+stm32wlxx-hal = { version = "0.6.1", optional = true, default-features = false }

--- a/chips/stm/bsps/README.md
+++ b/chips/stm/bsps/README.md
@@ -18,7 +18,21 @@ Regenerate the stubs with `scripts/gen_ioc_bsps.sh`. The script invokes
 `chips/stm/bsps/src`. MCU data comes from the bundled `rlvgl-chips-stm`
 archive, so no separate `mcu.json` is needed.
 
-## Available boards
+## Supported devices
 
 - `f407_demo`
 - `f429_demo`
+
+## Unsupported devices (partial)
+
+The following boards are known to be unsupported or require vendor
+crates that are not yet integrated. They are skipped by the BSP
+generation script.
+
+- `b_g473e_zest1s`
+- `b_g474e_dpow1`
+- `b_l072z_lrwan1`
+- `stm32wba65i_dk1`
+
+*This list of unsupported devices is not complete; other boards in the
+archive may also fail to build.*

--- a/scripts/gen_ioc_bsps.sh
+++ b/scripts/gen_ioc_bsps.sh
@@ -12,6 +12,9 @@ AF_JSON=${AF_JSON:-stm32_af.json}
 OUT_DIR=${OUT_DIR:-chips/stm/bsps/src}
 OPEN_PIN_DATA=${OPEN_PIN_DATA:-chips/stm/STM32_open_pin_data}
 BOARD_DIR="$OPEN_PIN_DATA/boards"
+# Boards lacking HAL or PAC support
+SKIP_BOARDS=(b_g473e_zest1s b_g474e_dpow1 b_l072z_lrwan1 stm32wba65i_dk1)
+
 
 if [ ! -x "$RLVGL_CREATOR" ]; then
   echo "warning: rlvgl-creator not found at $RLVGL_CREATOR" >&2
@@ -55,6 +58,10 @@ for ioc in "${iocs[@]}"; do
   done
   board="${board:-$raw}"
   board="$(echo "$board" | tr '[:upper:]' '[:lower:]' | tr '-' '_')"
+  if [[ " ${SKIP_BOARDS[*]} " == *" $board "* ]]; then
+    echo "[$count/$total] $board (skipped)"
+    continue
+  fi
   echo "[$count/$total] $board"
   out_dir="$OUT_DIR/$board"
   if "$RLVGL_CREATOR" bsp from-ioc "$ioc" "$AF_JSON" \

--- a/src/bin/creator/bsp/templates/hal.rs.jinja
+++ b/src/bin/creator/bsp/templates/hal.rs.jinja
@@ -17,11 +17,44 @@
 #![allow(clippy::too_many_arguments)]
 {% if mod_name %}#![cfg(feature = "{{ mod_name }}")]{% endif %}
 
-{%- set ports = [] -%}
-{%- for pin in spec.pinctrl -%}
-    {%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}
-{%- endfor -%}
-use stm32h7xx_hal::{gpio::Speed, pac, prelude::*{% for p in ports %}, gpio{{ p|lower }}::*{% endfor %}};
+{# collect unique GPIO port letters #}
+{% set ns = namespace(ports=[]) %}
+{% for pin in spec.pinctrl %}
+    {% if pin.pin[1] not in ns.ports %}{% set ns.ports = ns.ports + [pin.pin[1]] %}{% endif %}
+{% endfor %}
+
+{# derive HAL crate name from the MCU identifier #}
+{% set crate = namespace(letters='', digits='', digits_started=false, stop=false) %}
+{% for ch in spec.mcu[5:] %}
+    {% if not crate.stop %}
+        {% if ch >= 'A' and ch <= 'Z' %}
+            {% if crate.digits_started %}
+                {% set crate.stop = true %}
+            {% else %}
+                {% set crate.letters = crate.letters + ch %}
+            {% endif %}
+        {% elif ch >= '0' and ch <= '9' %}
+            {% set crate.digits_started = true %}
+            {% set crate.digits = crate.digits + ch %}
+        {% else %}
+            {% set crate.stop = true %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+{% set family = crate.letters | lower %}
+{% set nums = crate.digits %}
+{% if family == 'wb' %}
+    {% set hal_crate = 'stm32wb_hal' %}
+{% elif family == 'wl' %}
+    {% set hal_crate = 'stm32wlxx_hal' %}
+{% elif family == 'wba' %}
+    {% set hal_crate = 'stm32wba_hal' %}
+{% elif family == 'mp' %}
+    {% set hal_crate = 'stm32mp1_hal' %}
+{% else %}
+    {% set hal_crate = 'stm32' + family + nums[0:1] + 'xx_hal' %}
+{% endif %}
+use {{ hal_crate }}::{gpio::Speed, pac, prelude::*{% for p in ns.ports %}, gpio{{ p|lower }}::*{% endfor %}};
 
 {% macro gpio_bus(family) -%}
 {% if family[0:7] == "STM32H7" %}ahb4enr
@@ -32,7 +65,7 @@ use stm32h7xx_hal::{gpio::Speed, pac, prelude::*{% for p in ports %}, gpio{{ p|l
 {% else %}ahb1enr{% endif %}
 {%- endmacro %}
 {% macro port_bit(p) -%}
-{% set map = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10} %}
+{% set map = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25} %}
 {{ map[p] }}
 {%- endmacro %}
 {% macro port_l(pin) -%}{{ pin.pin[1]|lower }}{%- endmacro %}
@@ -61,29 +94,29 @@ use stm32h7xx_hal::{gpio::Speed, pac, prelude::*{% for p in ports %}, gpio{{ p|l
 /// Enables GPIO clocks required by the generated board.
 {% endif %}
 pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
-    {%- if ports|length -%}
-    {%- if grouped_writes -%}
-    const MASK: u32 = {%- for p in ports -%}(1u32 << {{ port_bit(p) }}){%- if not loop.last %} |{% endif %}{%- endfor %};
+    {% if ns.ports|length %}
+    {% if grouped_writes %}
+    const MASK: u32 = {% for p in ns.ports %}(1u32 << {{ port_bit(p) }}){% if not loop.last %} |{% endif %}{% endfor %};
     dp.RCC.{{ gpio_bus(spec.mcu) }}.modify(|r, w| unsafe { w.bits(r.bits() | MASK) });
-    {%- else -%}
-    {%- for p in ports -%}
+    {% else %}
+    {% for p in ns.ports %}
     dp.RCC.{{ gpio_bus(spec.mcu) }}.modify(|_, w| w.gpio{{ p|lower }}en().set_bit());
-    {%- endfor -%}
-    {%- endif -%}
-    {%- endif -%}
+    {% endfor %}
+    {% endif %}
+    {% endif %}
 }
 
-{%- if spec.pinctrl|length -%}
-{%- if meta is defined %}
+{% if spec.pinctrl|length %}
+{% if meta is defined %}
 /// Configures pins for {{ meta.board }} using the HAL API.
-{%- else %}
+{% else %}
 /// Configures pins using the HAL API.
-{%- endif %}
+{% endif %}
 pub fn configure_pins_hal(dp: &pac::Peripherals) {
-{%- for p in ports %}
+{% for p in ns.ports %}
     let gpio{{ p|lower }} = dp.GPIO{{ p }}.split();
-{%- endfor %}
-{%- for pin in spec.pinctrl %}
+{% endfor %}
+{% for pin in spec.pinctrl %}
     {%- set is_gpio = pin.func[0:5] == "GPIO_" %}
     {%- set is_i2c  = pin.func[0:3] == "I2C" %}
     {%- set is_ana  = pin.func[0:3] == "ADC" or ("Analog" in pin.func) %}
@@ -101,12 +134,12 @@ pub fn configure_pins_hal(dp: &pac::Peripherals) {
         {%- else %}                      gpio{{ port_l(pin) }}.{{ field(pin) }}.into_alternate::<{{ pin.af }}>()
         {%- endif -%}
     {%- endif %}
-    {%- if pin.func[0:18] == "USB_OTG_HS_ULPI_" or pin.func[0:5] == "SDMMC" or pin.func[0:3] == "SPI" %}
+    {% if pin.func[0:18] == "USB_OTG_HS_ULPI_" or pin.func[0:5] == "SDMMC" or pin.func[0:3] == "SPI" %}
         .set_speed(Speed::VeryHigh)
-    {%- endif %};
-{%- endfor %}
+    {% endif %};
+{% endfor %}
 }
-{%- endif %}
+{% endif %}
 
 {% if meta is defined %}
 /// Enables peripheral clocks for {{ meta.board }}.

--- a/src/bin/creator/bsp/templates/pac.rs.jinja
+++ b/src/bin/creator/bsp/templates/pac.rs.jinja
@@ -17,11 +17,49 @@
 #![allow(clippy::too_many_arguments)]
 {% if mod_name %}#![cfg(feature = "{{ mod_name }}")]{% endif %}
 
-{%- set ports = [] -%}
-{%- for pin in spec.pinctrl -%}
-    {%- if pin.pin[1] not in ports -%}{% set ports = ports + [pin.pin[1]] %}{%- endif -%}
-{%- endfor -%}
-use stm32h7::stm32h747 as pac;
+{# collect unique GPIO port letters #}
+{% set ns = namespace(ports=[]) %}
+{% for pin in spec.pinctrl %}
+    {% if pin.pin[1] not in ns.ports %}{% set ns.ports = ns.ports + [pin.pin[1]] %}{% endif %}
+{% endfor %}
+
+{# derive PAC crate and module from the MCU identifier #}
+{% set crate = namespace(letters='', digits='', digits_started=false, stop=false) %}
+{% for ch in spec.mcu[5:] %}
+    {% if not crate.stop %}
+        {% if ch >= 'A' and ch <= 'Z' %}
+            {% if crate.digits_started %}
+                {% set crate.stop = true %}
+            {% else %}
+                {% set crate.letters = crate.letters + ch %}
+            {% endif %}
+        {% elif ch >= '0' and ch <= '9' %}
+            {% set crate.digits_started = true %}
+            {% set crate.digits = crate.digits + ch %}
+        {% else %}
+            {% set crate.stop = true %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+{% set family = crate.letters | lower %}
+{% set nums = crate.digits %}
+{% if family == 'wb' %}
+    {% set pac_crate = 'stm32wb' %}
+    {% set pac_mod = pac_crate + nums %}
+{% elif family == 'wl' %}
+    {% set pac_crate = 'stm32wl' %}
+    {% set pac_mod = pac_crate + nums %}
+{% elif family == 'wba' %}
+    {% set pac_crate = 'stm32wba' %}
+    {% set pac_mod = pac_crate + nums %}
+{% elif family == 'mp' %}
+    {% set pac_crate = 'stm32mp1' %}
+    {% set pac_mod = pac_crate + nums %}
+{% else %}
+    {% set pac_crate = 'stm32' + family + nums[0:1] %}
+    {% set pac_mod = pac_crate + nums[1:] %}
+{% endif %}
+use {{ pac_crate }}::{{ pac_mod }} as pac;
 
 {%- macro gpio_bus(family) -%}
 {% if family[0:7] == "STM32H7" %}ahb4enr
@@ -32,7 +70,7 @@ use stm32h7::stm32h747 as pac;
 {% else %}ahb1enr{% endif %}
 {%- endmacro %}
 {% macro port_bit(p) -%}
-{% set map = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10} %}
+{% set map = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25} %}
 {{ map[p] }}
 {%- endmacro %}
 {% macro port_u(pin) -%}{{ pin.pin[1] }}{%- endmacro %}
@@ -53,33 +91,33 @@ use stm32h7::stm32h747 as pac;
 {%- endif -%}
 {%- endmacro %}
 
-{%- if meta is defined -%}
+{% if meta is defined %}
 /// Enables GPIO clocks required by {{ meta.board }}.
-{%- else -%}
+{% else %}
 /// Enables GPIO clocks required by the generated board.
-{%- endif -%}
+{% endif %}
 pub fn enable_gpio_clocks(dp: &pac::Peripherals) {
-    {%- if ports|length -%}
-    {%- if grouped_writes -%}
-    const MASK: u32 = {%- for p in ports -%}(1u32 << {{ port_bit(p) }}){%- if not loop.last %} |{% endif %}{%- endfor %};
+    {% if ns.ports|length %}
+    {% if grouped_writes %}
+    const MASK: u32 = {% for p in ns.ports %}(1u32 << {{ port_bit(p) }}){% if not loop.last %} |{% endif %}{% endfor %};
     dp.RCC.{{ gpio_bus(spec.mcu) }}.modify(|r, w| unsafe { w.bits(r.bits() | MASK) });
-    {%- else -%}
-    {%- for p in ports -%}
+    {% else %}
+    {% for p in ns.ports %}
     dp.RCC.{{ gpio_bus(spec.mcu) }}.modify(|_, w| w.gpio{{ p|lower }}en().set_bit());
-    {%- endfor -%}
-    {%- endif -%}
-    {%- endif -%}
+    {% endfor %}
+    {% endif %}
+    {% endif %}
 }
 
-{%- if spec.pinctrl|length -%}
-{%- if meta is defined -%}
+{% if spec.pinctrl|length %}
+{% if meta is defined %}
 /// Configures pins for {{ meta.board }} using PAC registers.
-{%- else -%}
+{% else %}
 /// Configures pins using PAC registers.
-{%- endif -%}
+{% endif %}
 pub fn configure_pins_pac(dp: &pac::Peripherals) {
-{%- if grouped_writes -%}
-    {%- for p in ports -%}
+{% if grouped_writes %}
+{% for p in ns.ports %}
     // GPIO{{ p }}
     dp.GPIO{{ p }}.pupdr.modify(|r, w| unsafe {
         let mut bits = r.bits();
@@ -136,9 +174,9 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         {%- endfor -%}
         w.bits(bits)
     });
-    {%- endfor -%}
-{%- else -%}
-{%- for pin in spec.pinctrl -%}
+{% endfor %}
+{% else %}
+{% for pin in spec.pinctrl %}
     // {{ pin.pin }} {{ pin.func }} AF{{ pin.af }}
     let shift = {{ idx(pin) }} * 2;
     dp.GPIO{{ port_u(pin) }}.pupdr.modify(|r, w| unsafe {
@@ -187,10 +225,10 @@ pub fn configure_pins_pac(dp: &pac::Peripherals) {
         {%- endif -%}
         w.bits(bits)
     });
-{%- endfor -%}
-{%- endif -%}
+{% endfor %}
+{% endif %}
 }
-{%- endif -%}
+{% endif %}
 
 {% if meta is defined %}
 /// Disables unused peripherals for {{ meta.board }} and masks their interrupts.


### PR DESCRIPTION
## Summary
- derive HAL crate names from MCU identifier to select correct `stm32*xx_hal` import
- compute PAC crate/module paths from the MCU identifier for proper `stm32*` PAC imports
- add optional dependencies for all STM32 HAL crates and wire crate features to them
- document supported and unsupported STM32 BSPs and skip unsupported boards during generation

## Testing
- `cargo build --bin rlvgl-creator --features creator,creator_ui`
- `scripts/gen_ioc_bsps.sh`
- `./scripts/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ae5c41de9c83338181c2f11cd92240