### PR TITLE
Add GIF demo and headless image checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "rlvgl-sim"
 path = "examples/sim/src/main.rs"
-required-features = ["simulator", "qrcode", "png", "jpeg", "fontdue"]
+required-features = ["simulator", "qrcode", "png", "jpeg", "gif", "fontdue"]
 
 [[bin]]
 name = "rlvgl-stm32h747i-disco"

--- a/examples/sim/src/main.rs
+++ b/examples/sim/src/main.rs
@@ -48,6 +48,9 @@ fn main() {
     let mut path = None;
     let mut headless_path: Option<String> = None;
     let mut use_wgpi = false;
+    let mut show_qr = false;
+    let mut show_png = false;
+    let mut show_gif = false;
 
     let mut args = env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -66,6 +69,12 @@ fn main() {
             }
         } else if arg == "--wgpi" {
             use_wgpi = true;
+        } else if arg == "--qrcode" {
+            show_qr = true;
+        } else if arg == "--png" {
+            show_png = true;
+        } else if arg == "--gif" {
+            show_gif = true;
         } else if arg.starts_with("--headless") {
             if let Some(eq) = arg.split_once('=') {
                 headless_path = Some(eq.1.to_string());
@@ -84,6 +93,25 @@ fn main() {
     let root = demo.root.clone();
     let pending = demo.pending.clone();
     let to_remove = demo.to_remove.clone();
+
+    if show_qr {
+        #[cfg(feature = "qrcode")]
+        root.borrow_mut()
+            .children
+            .push(common_demo::build_plugin_demo(width as u32, height as u32));
+    }
+    if show_png {
+        #[cfg(feature = "png")]
+        root.borrow_mut()
+            .children
+            .push(common_demo::build_png_demo(width as u32, height as u32));
+    }
+    if show_gif {
+        #[cfg(feature = "gif")]
+        root.borrow_mut()
+            .children
+            .push(common_demo::build_gif_demo(width as u32, height as u32));
+    }
 
     let mut frame_cb = {
         let root = root.clone();

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -28,3 +28,53 @@ fn headless_renders_ascii_screen() {
         }
     }
 }
+
+fn assert_lower_right(ascii: &str) {
+    let lines: Vec<&str> = ascii.lines().collect();
+    assert_eq!(lines.len(), HEIGHT);
+    let mut found = false;
+    for (y, line) in lines.iter().enumerate() {
+        assert_eq!(line.len(), WIDTH);
+        for (x, ch) in line.chars().enumerate() {
+            if x >= WIDTH / 3 && y >= HEIGHT / 3 {
+                if ch != '@' {
+                    found = true;
+                }
+            } else {
+                assert_eq!(ch, '@', "unexpected char at ({x},{y})");
+            }
+        }
+    }
+    assert!(found, "no content in lower-right region");
+}
+
+fn run_demo(flag: &str) -> String {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("screen.txt");
+    let status = Command::new(env!("CARGO_BIN_EXE_rlvgl-sim"))
+        .arg("--headless")
+        .arg(&path)
+        .arg(flag)
+        .status()
+        .expect("failed to run rlvgl-sim");
+    assert!(status.success());
+    fs::read_to_string(&path).expect("read ascii")
+}
+
+#[test]
+fn png_demo_in_lower_right() {
+    let ascii = run_demo("--png");
+    assert_lower_right(&ascii);
+}
+
+#[test]
+fn qrcode_demo_in_lower_right() {
+    let ascii = run_demo("--qrcode");
+    assert_lower_right(&ascii);
+}
+
+#[test]
+fn gif_demo_in_lower_right() {
+    let ascii = run_demo("--gif");
+    assert_lower_right(&ascii);
+}


### PR DESCRIPTION
## Summary
- fix PNG panic by anchoring image demos to dynamic screen size
- add embedded GIF demo and CLI flags for PNG/QR/GIF headless renders
- test that PNG, QR code, and GIF content only appears in lower-right region

## Testing
- ⚠️ `./scripts/pre-commit.sh` *(failed: exceeded execution time)*
- ⚠️ `cargo test --test headless --features "simulator,qrcode,png,gif,jpeg,fontdue" -- --nocapture` *(failed: exceeded execution time)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8f2d84ac83339197d41cd4966f06