### PR TITLE
docs: highlight BSP generation and STM BSP crate

### DIFF
--- a/README-CREATOR.md
+++ b/README-CREATOR.md
@@ -1,16 +1,16 @@
 <!--
-README-CREATOR.md - Guide to rlvgl-creator asset workflows.
+README-CREATOR.md - Guide to rlvgl-creator 🆕 asset workflows.
 -->
 <p align="center">
   <img src="./rlvgl-logo.png" alt="rlvgl" />
 </p>
 
-# rlvgl-creator
+# rlvgl-creator 🆕
 
-Package: `rlvgl-creator`.
+Package: `rlvgl-creator` 🆕.
 
 ## Overview
-`rlvgl-creator` assembles and transforms assets for rlvgl applications. It groups icons, fonts, and media into an asset pack and records metadata in a manifest to simplify reuse across targets.
+`rlvgl-creator` 🆕 assembles and transforms assets for rlvgl applications. It groups icons, fonts, and media into an asset pack and records metadata in a manifest to simplify reuse across targets. It can also generate Rust BSP code from STM32CubeMX `.ioc` files.
 
 ### Terms
 - **Asset pack**: A directory tree containing `icons/`, `fonts/`, `media/`, and a `manifest.yml` that tracks each resource.
@@ -22,23 +22,26 @@ Package: `rlvgl-creator`.
 
 ### Initialize a new asset pack
 ```bash
-rlvgl-creator init
-rlvgl-creator add-target host vendor
+# rlvgl-creator 🆕
+rlvgl-creator init # 🆕
+rlvgl-creator add-target host vendor # 🆕
 ```
 `init` creates the asset directories and an empty manifest. `add-target` registers a `host` target whose converted assets will be placed in the `vendor` directory used by the simulator.
 
 ### Import and convert assets
 Place raw files into the asset directories, then scan and convert them:
 ```bash
-rlvgl-creator scan
-rlvgl-creator convert
+# rlvgl-creator 🆕
+rlvgl-creator scan # 🆕
+rlvgl-creator convert # 🆕
 ```
 `scan` computes hashes for new or changed assets and refreshes `manifest.yml`. `convert` normalizes images to raw RGBA and prepares fonts or media for each target.
 
 ### Preview and scaffold
 ```bash
-rlvgl-creator preview
-rlvgl-creator scaffold assets-pack
+# rlvgl-creator 🆕
+rlvgl-creator preview # 🆕
+rlvgl-creator scaffold assets-pack # 🆕
 ```
 `preview` writes thumbnails under `thumbs/` so assets can be reviewed quickly. `scaffold` generates a crate named `assets-pack` that either embeds assets or vendors them into the simulator at build time.
 
@@ -69,7 +72,7 @@ This pattern safely expands to an empty list when `name` is absent.
 
 ## Chip and board database integration
 
-`rlvgl-creator` consumes chip and board definitions from the `rlvgl-chips-*` crates under
+`rlvgl-creator` 🆕 consumes chip and board definitions from the `rlvgl-chips-*` crates under
 `chipdb/`. These crates embed vendor JSON data so the CLI and UI can populate vendor,
 microcontroller and board selections. When regenerating pin data, bump the crate versions
 before publishing:
@@ -81,22 +84,30 @@ python tools/bump_vendor_versions.py --path chipdb
 No additional configuration is required; the creator automatically loads all available
 vendor crates on startup.
 
+> ⚠️ The legacy `board` subcommand remains but is deprecated in favor of BSP generation.
+
 To convert a custom CubeMX project into a board overlay, run:
 
 ```bash
-rlvgl-creator board from-ioc project.ioc MyBoard MyBoard.json
+# rlvgl-creator 🆕
+rlvgl-creator board from-ioc project.ioc MyBoard MyBoard.json # 🆕
 ```
 
 The CLI detects the MCU automatically and resolves alternate-function numbers
 using the bundled database. The resulting JSON can be placed under `boards/`
-for use by `rlvgl-creator`.
+for use by `rlvgl-creator` 🆕.
 
 ## Batch BSP generation
 
 Run `scripts/gen_ioc_bsps.sh` to convert every CubeMX `.ioc` under
 `chips/stm/STM32_open_pin_data/boards`. The script invokes
-`rlvgl-creator` for each file and relies on the `rlvgl-chips-stm`
+`rlvgl-creator` 🆕 for each file and relies on the `rlvgl-chips-stm`
 archive for MCU metadata, so no standalone `mcu.json` is required.
 
-See [chips/stm/bsps/README.md](./chips/stm/bsps/README.md) for details on the generated stubs.
+Generated modules are published as [`rlvgl-bsps-stm` 🆕](./chips/stm/bsps/README.md).
+Include a module in your project:
+
+```rust
+use rlvgl_bsps_stm::f407_demo as bsp;
+```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Package: `rlvgl`
 - [examples](./examples/README.md) – Sample applications and board demos
 - [docs](./docs/README.md) – Project documentation and task lists
 - [lvgl](./lvgl/README.md) – C submodule (reference only)
+- [chips/stm/bsps](./chips/stm/bsps/README.md) 🆕 – Generated STM32 BSP stubs
 
 ## Vendor chip databases
 
@@ -45,9 +46,16 @@ license files. When building a vendor crate, set `RLVGL_CHIP_SRC` to the
 directory containing these JSON files so the build script can embed them
 via `include_bytes!`.
 
-## BSP Generator (`rlvgl-creator`)
+## STM32CubeMX BSP generation 🆕
 
-`rlvgl-creator` offers a two-stage pipeline for board support packages:
+`rlvgl-creator` 🆕 converts STM32 CubeMX `.ioc` projects into board support
+stubs. Generated modules ship in
+[`rlvgl-bsps-stm` 🆕](./chips/stm/bsps/README.md). The older `board`
+overlay support remains but is deprecated.
+
+## BSP Generator (`rlvgl-creator` 🆕)
+
+`rlvgl-creator` 🆕 offers a two-stage pipeline for board support packages:
 
 1. **Import** vendor project files (e.g., STM32CubeMX `.ioc`, NXP `.mex`,
    RP2040 YAML). Each adapter mines the vendor data and emits a small, vendor-neutral
@@ -83,8 +91,8 @@ python tools/afdb/st_extract_af.py --input stm32_af.csv --output af.json
 python tools/afdb/st_extract_af.py --input boards/ --output build/stm
 ```
 
-The resulting `af.json` can be passed to `rlvgl-creator platform import` via
-`--afdb af.json`.
+The resulting `af.json` can be passed to `rlvgl-creator` 🆕 via
+`platform import --afdb af.json`.
 
 To package vendor chip databases for testing or publishing, run:
 
@@ -93,7 +101,7 @@ tools/build_vendor.sh
 RLVGL_CHIP_SRC=chipdb/rlvgl-chips-stm/generated cargo build -p rlvgl-chips-stm
 ```
 
-For a full asset workflow overview see [README-CREATOR.md](./README-CREATOR.md).
+For a full asset workflow overview see the [rlvgl-creator 🆕 README](./README-CREATOR.md).
 Command details live in [docs/CREATOR-CLI.md](./docs/CREATOR-CLI.md).
 
 ### IR schema

--- a/chips/stm/bsps/README.md
+++ b/chips/stm/bsps/README.md
@@ -5,15 +5,16 @@ chips/stm/bsps/README.md - STM32 BSP stub generation notes.
   <img src="../../../rlvgl-logo.png" alt="rlvgl" />
 </p>
 
-# rlvgl-bsps-stm
-Package: `rlvgl-bsps-stm`
+# rlvgl-bsps-stm 🆕
+Package: `rlvgl-bsps-stm` 🆕
 
-Board support package stubs for STM32 boards used by `rlvgl-creator`.
+Board support package stubs for STM32 boards used by `rlvgl-creator` 🆕.
+The legacy `board` overlay path is kept for compatibility but is deprecated.
 This crate now includes simple modules generated from CubeMX `.ioc`
 files with basic pin mappings.
 
 Regenerate the stubs with `scripts/gen_ioc_bsps.sh`. The script invokes
-`rlvgl-creator` for every `.ioc` under
+`rlvgl-creator` 🆕 for every `.ioc` under
 `chips/stm/STM32_open_pin_data/boards` and writes the modules to
 `chips/stm/bsps/src`. MCU data comes from the bundled `rlvgl-chips-stm`
 archive, so no separate `mcu.json` is needed.


### PR DESCRIPTION
## Summary
- document STM32CubeMX `.ioc` to BSP support via `rlvgl-creator`
- note deprecated `board` overlays and point to `rlvgl-bsps-stm` crate
- link new `rlvgl-bsps-stm` examples and add `🆕` markers

## Testing
- `scripts/check-links.sh README.md README-CREATOR.md chips/stm/bsps/README.md` *(fails: lychee not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68ae93c531dc83339baedd5c66f87165